### PR TITLE
Add REST API outputs to support Terraform

### DIFF
--- a/cloudformation/thin-egress-app.yaml
+++ b/cloudformation/thin-egress-app.yaml
@@ -196,6 +196,10 @@ Conditions:
 Outputs:
   ApiEndpoint:
     Value: !Sub "https://${EgressApiGateway}.execute-api.${AWS::Region}.amazonaws.com/${EgressStage}/"
+  RestApiId:
+    Value: !Ref EgressApiGateway
+  RestApiRootResourceId:
+    Value: !GetAtt EgressApiGateway.RootResourceId
   URSredirectURI:
     Value: !Sub "https://${EgressApiGateway}.execute-api.${AWS::Region}.amazonaws.com/${EgressStage}/login"
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,3 +1,10 @@
+output "rest_api" {
+  value = {
+    id               = aws_cloudformation_stack.thin_egress_app.outputs.RestApiId
+    root_resource_id = aws_cloudformation_stack.thin_egress_app.outputs.RestApiRootResourceId
+  }
+}
+
 output "api_endpoint" {
   value = var.domain_name == null ? aws_cloudformation_stack.thin_egress_app.outputs.ApiEndpoint : "https://${var.domain_name}/"
 }


### PR DESCRIPTION
Adding two additional outputs to the CF stack which are needed to support integrating the S3 credentials endpoint.