### PR TITLE
fetch CF output after update by depending

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -59,3 +59,10 @@ resource "aws_cloudformation_stack" "thin_egress_app" {
     VPCSubnetIDs                    = join(",", var.vpc_subnet_ids)
   }
 }
+
+data "aws_cloudformation_stack" "thin_egress_stack" {
+  name = aws_cloudformation_stack.thin_egress_app.name
+  depends_on = [
+    aws_cloudformation_stack.thin_egress_app
+  ]
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -14,5 +14,5 @@ output "urs_redirect_uri" {
 }
 
 output "egress_log_group" {
-  value = var.log_api_gateway_to_cloudwatch ? aws_cloudformation_stack.thin_egress_app.outputs.ApiGatewayLogGroupEgress : null
+  value = var.log_api_gateway_to_cloudwatch ? data.aws_cloudformation_stack.thin_egress_stack.outputs.ApiGatewayLogGroupEgress : null
 }


### PR DESCRIPTION
This PR fixes a failure that occurs when `var.log_api_gateway_to_cloudwatch` is enabled on an existing TEA deployment. Due to the way Terraform fetches outputs, it will fail saying that the `ApiGatewayLogGroupEgress` output does not exist, which is because it attempts to fetch the output in a phase before applying the change that will actually create the output in Cloudformation, which is triggered off the same var.

By using a data resource that depends on the Cloudformation resource, we can delay evaluation of the output until after the update has been applied, resolving the above issue.