### PR TITLE
NGAP2 Compatibility

### DIFF
--- a/cloudformation/thin-egress-app.yaml
+++ b/cloudformation/thin-egress-app.yaml
@@ -252,7 +252,6 @@ Conditions:
   CreateDownloadRole: !Equals [ !Ref DownloadRoleArn, "" ]
   UsePermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryName, "" ] ]
   UsePrivateVPC: !Not [ !Equals [ !Ref PrivateVPC, "" ] ]
-  DomainInNgap: !And [ !Condition DomainNameIsSet, !Condition UsePrivateVPC ]
   DomainNotInNgap: !And [ !Condition DomainNameIsSet, !Not [ !Condition UsePrivateVPC ] ] 
 
 Outputs:

--- a/cloudformation/thin-egress-app.yaml
+++ b/cloudformation/thin-egress-app.yaml
@@ -252,7 +252,7 @@ Conditions:
   CreateDownloadRole: !Equals [ !Ref DownloadRoleArn, "" ]
   UsePermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryName, "" ] ]
   UsePrivateVPC: !Not [ !Equals [ !Ref PrivateVPC, "" ] ]
-  DomainNotInNgap: !And [ !Condition DomainNameIsSet, !Not [ !Condition UsePrivateVPC ] ] 
+  DomainNotInNgap: !And [ !Condition DomainNameIsSet, !Not [ !Condition UsePrivateVPC ] ]
 
 Outputs:
   ExternalEndpoint:
@@ -538,7 +538,7 @@ Resources:
       - EgressApiGateway
     Properties:
       CertificateArn: DomainCertArn # Not NGAP using cert.
-      DomainName: !Ref DomainName 
+      DomainName: !Ref DomainName
 
   ExtDomainBasePathMap:
     Type: AWS::ApiGateway::BasePathMapping

--- a/cloudformation/thin-egress-app.yaml
+++ b/cloudformation/thin-egress-app.yaml
@@ -252,7 +252,8 @@ Conditions:
   CreateDownloadRole: !Equals [ !Ref DownloadRoleArn, "" ]
   UsePermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryName, "" ] ]
   UsePrivateVPC: !Not [ !Equals [ !Ref PrivateVPC, "" ] ]
-
+  DomainInNgap: !And [ !Condition DomainNameIsSet, !Condition UsePrivateVPC ]
+  DomainNotInNgap: !And [ !Condition DomainNameIsSet, !Not [ !Condition UsePrivateVPC ] ] 
 
 Outputs:
   ExternalEndpoint:
@@ -533,20 +534,16 @@ Resources:
 
   ExtDomainName:
     Type: AWS::ApiGateway::DomainName
-    Condition: DomainNameIsSet
+    Condition: DomainNotInNgap
     DependsOn:
       - EgressApiGateway
     Properties:
-      CertificateArn:
-        !If
-        - UsePrivateVPC
-        - !Ref "AWS::NoValue" # If NGAP, we can't use cert here
-        - !Ref DomainCertArn # Not NGAP using cert.
-      DomainName: !Ref DomainName
+      CertificateArn: DomainCertArn # Not NGAP using cert.
+      DomainName: !Ref DomainName 
 
   ExtDomainBasePathMap:
     Type: AWS::ApiGateway::BasePathMapping
-    Condition: DomainNameIsSet
+    Condition: DomainNotInNgap
     DependsOn:
       - ExtDomainName
     Properties:


### PR DESCRIPTION
Only create ExtDomainName if a domain is set, and the app is NOT in NGAP. 
creating `AWS::ApiGateway::DomainName` forces an APIGateway to EdgeOptimized instead of PRIVATE. 