### PR TITLE
Store dependencylayer in Terraform zip

### DIFF
--- a/build/Jenkinsfile
+++ b/build/Jenkinsfile
@@ -99,8 +99,9 @@ pipeline {
 
         // Zip up terraform
         sh "echo '>> Building Terraform Zip....'"
-        sh "cd ${WORKSPACE}/terraform && cp ../${CODE_ARCHIVE_FILENAME} ./lambda.zip && zip ../${TF_ZIP_FILENAME} *.tf lambda.zip"
-
+        sh "cp ${WORKSPACE}/${CODE_ARCHIVE_FILENAME} ${WORKSPACE}/terraform/lambda.zip"
+        sh "cp ${WORKSPACE}/${DEPENDENCYLAYERFILENAME} ${WORKSPACE}/terraform/dependencylayer.zip"
+        sh "cd ${WORKSPACE}/terraform && zip ../${TF_ZIP_FILENAME} *.tf lambda.zip dependencylayer.zip"
       }
    }
    // Push packages to AWS and deploy new version

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -23,6 +23,13 @@ resource "aws_s3_bucket_object" "lambda_source" {
   etag   = filemd5("${path.module}/lambda.zip")
 }
 
+resource "aws_s3_bucket_object" "lambda_code_dependency_archive" {
+  bucket = aws_s3_bucket.lambda_source.bucket
+  key    = "dependencylayer.zip"
+  source = "${path.module}/dependencylayer.zip"
+  etag   = filemd5("${path.module}/dependencylayer.zip")
+}
+
 resource "aws_cloudformation_stack" "thin_egress_app" {
   name         = var.stack_name
   template_url = var.template_url
@@ -41,7 +48,7 @@ resource "aws_cloudformation_stack" "thin_egress_app" {
     HtmlTemplateDir                 = var.html_template_dir
     JwtAlgo                         = var.jwt_algo
     JwtKeySecretName                = var.jwt_secret_name
-    LambdaCodeDependencyArchive     = var.lambda_code_dependency_archive_key
+    LambdaCodeDependencyArchive     = aws_s3_bucket_object.lambda_code_dependency_archive.key
     LambdaCodeS3Bucket              = aws_s3_bucket_object.lambda_source.bucket
     LambdaCodeS3Key                 = aws_s3_bucket_object.lambda_source.key
     LambdaTimeout                   = var.lambda_timeout


### PR DESCRIPTION
v47 of TEA is failing to deploy in Terraform. The TEA lambda code is stored in `lambda.zip`, which is included in the TF module's zip file. Some time recently, a `dependencylayer` zip was added as well. That file is not being included in the TF zip file, so TF deployments are failing in v47. This PR should fix that.