### PR TITLE
Updates TEA outputs to provide consistent internal API reference

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -9,6 +9,10 @@ output "api_endpoint" {
   value = var.domain_name == null ? aws_cloudformation_stack.thin_egress_app.outputs.ApiEndpoint : "https://${var.domain_name}/"
 }
 
+output "internal_api_endpoint" {
+  value = aws_cloudformation_stack.thin_egress_app.outputs.ApiEndpoint
+}
+
 output "urs_redirect_uri" {
   value = var.domain_name == null ? aws_cloudformation_stack.thin_egress_app.outputs.URSredirectURI : "https://${var.domain_name}/login"
 }


### PR DESCRIPTION
This is needed as the api_endpoint output provides the external facing
endpoint, however we don't always want internal/deployment queries to hit cloudfront/external access solutions