### PR TITLE
Add a semi-function test for bearer token support

### DIFF
--- a/build/test/download_test.py
+++ b/build/test/download_test.py
@@ -52,7 +52,7 @@ MAP_PATHS = sorted(["SA/OCN", "SA/OCN_CH", "SB/OCN", "SB/OCN_CH"])
 
 # Configuration:
 TEST_RESULT_BUCKET = os.getenv("TEST_RESULT_BUCKET", 'asf.public.code')
-TEST_RESULT_OBJECT =  os.getenv("TEST_RESULT_OBJECT", 'thin-egress-app/testresults-b.json')
+TEST_RESULT_OBJECT =  os.getenv("TEST_RESULT_OBJECT", 'thin-egress-app/testresults.json')
 LOCATE_BUCKET = os.getenv("LOCATE_BUCKET", 's1-ocn-1e29d408')
 
 # Global variable we'll use for our tests

--- a/build/test/download_test.py
+++ b/build/test/download_test.py
@@ -7,6 +7,7 @@ import requests
 from requests.auth import HTTPBasicAuth
 import logging
 import json
+import base64
 from datetime import datetime
 
 logging.getLogger('boto3').setLevel(logging.ERROR)

--- a/build/test/download_test.py
+++ b/build/test/download_test.py
@@ -224,6 +224,34 @@ class authed_download_test(unittest.TestCase):
         paths = sorted(json.loads(r.content))
         self.assertEqual(paths, MAP_PATHS)
 
+    # Validate EDL token works (if a little incestously)
+    def test_vallidate_bearer_token_works(self):
+        url = f"{APIROOT}/{METADATA_FILE}"
+        global cookiejar
+
+        # Find the token
+        token = None
+        for cookie in cookiejar:
+            # Find the 'asf-urs' cookie...
+            if cookie.name == 'asf-urs':
+                # Grab the JWT payload:
+                cookie_b64 = cookie.value.split(".")[1]
+                # Fix the padding:
+                cookie_b64 += '='* (4 - (len(cookie_b64)%4))
+                # Decode & Load...
+                cookie_json = json.loads(base64.b64decode(cookie_b64))
+                if 'urs-access-token' in cookie_json:
+                    token = cookie_json['urs-access-token']
+
+        log.info(f"Make sure we were able to decode a token from the cookie: {token} (Expect not None)")
+        self.assertTrue(token is not None)
+
+        log.info(f"Attempting to download {url} using the token as a Bearer token")
+        r = requests.get(url, headers = {"Authorization": f"Bearer {token}"})
+
+        log.info(f"Bearer Token Download attempt Return Code: {r.status_code} (Expect 200)")
+        # FIXME: This should work, but not until its release into production
+        # self.assertEqual(r.status_code, 200)
 
 def main():
 


### PR DESCRIPTION
This requires functionality NOT in production EDL.