### PR TITLE
use TF lookup() function to conditionally add egress_lambda_name output

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -22,5 +22,5 @@ output "egress_log_group" {
 }
 
 output "egress_lambda_name" {
-  value = aws_cloudformation_stack.thin_egress_app.outputs.EgressLambdaName
+  value = lookup(aws_cloudformation_stack.thin_egress_app.outputs, "EgressLambdaName", null)
 }


### PR DESCRIPTION
When trying to upgrade from TEA build 88 to TEA build 100+ for a Cumulus deployment, Cumulus users (myself included) are getting this error:

```
Error: Missing map element

  on .terraform/modules/thin_egress_app/outputs.tf line 25, in output "egress_lambda_name":
  25:   value = aws_cloudformation_stack.thin_egress_app.outputs.EgressLambdaName
    |----------------
    | aws_cloudformation_stack.thin_egress_app.outputs is map of string with 5 elements

This map does not have an element with the key "EgressLambdaName".
```

See ticket CUMULUS-2258 for other impacted users.

After investigating the issue, it is caused by the fact that the [Terraform code refers to an output from Cloudformation stack named `EgressLambdaName`](https://github.com/asfadmin/thin-egress-app/blob/devel/terraform/outputs.tf#L25), but that output **does not exist** until the Cloudformation stack has been re-deployed for TEA build 98+. And since [Terraform evaluates outputs before apply](https://github.com/hashicorp/terraform/issues/23365) (at least on Terraform v0.12 used by Cumulus), the Terraform `apply` stage fails because the Terraform output is trying to reference a Cloudformation stack output that doesn't exist yet.

Fortunately, the fix for this issue added by this PR is relatively simple: use the [Terraform `lookup` function](https://www.terraform.io/docs/configuration/functions/lookup.html) to make the Terraform output conditional so that there is no failure if it doesn't yet exist, but the correct value is used if the Cloudformation stack output does exist.

Also, since [I'm the one who added this output to the TEA code in the first place](https://github.com/asfadmin/thin-egress-app/pull/237), mea culpa for not recognizing that this could be a possible issue.