### PR TITLE
More powerful secret destruction

### DIFF
--- a/build/deploy.sh
+++ b/build/deploy.sh
@@ -139,8 +139,8 @@ if [ ! -z "$DESTROY" ]; then
    aws $AWSENV cloudformation delete-stack --stack-name ${DESTROY}
 
    echo ">> ☠️  Destroying Secrets ..."
-   aws $AWSENV secretsmanager delete-secret --secret-id jwt_creds_for_${DESTROY}
-   aws $AWSENV secretsmanager delete-secret --secret-id urs_creds_for_${DESTROY}
+   aws $AWSENV secretsmanager delete-secret --force-delete-without-recovery --secret-id jwt_creds_for_${DESTROY}
+   aws $AWSENV secretsmanager delete-secret --force-delete-without-recovery --secret-id urs_creds_for_${DESTROY}
 
    echo ">> ☠️  Destroying Buckets ..."
    for i in ${DESTROY}-config ${DESTROY}-code ${DESTROY}-restricted ${DESTROY}-public; do


### PR DESCRIPTION
Without `--force-delete-without-recovery`, the secrets are left in a `marked for delete` purgatory where they cannot be updated but don't show up in the AWS console. 