### PR TITLE
Allow bearer token validation for accessing restricted data

### DIFF
--- a/build/test/download_test.py
+++ b/build/test/download_test.py
@@ -68,7 +68,7 @@ LOCATE_BUCKET = os.getenv("LOCATE_BUCKET", default_locate_bucket)
 # Global variable we'll use for our tests
 cookiejar = []
 urs_username = os.getenv("URS_USERNAME")
-urs_password = os.getenv("URS_PASSWORD", "0x5&I!]F0C{)_.c@5py")
+urs_password = os.getenv("URS_PASSWORD")
 
 
 def env_var_check():

--- a/build/test/download_test.py
+++ b/build/test/download_test.py
@@ -276,20 +276,18 @@ class authed_download_test(unittest.TestCase):
         paths = sorted(json.loads(r.content))
         self.assertEqual(paths, MAP_PATHS)
 
-    # Validate EDL token works (if a little incestously)
-    def test_vallidate_bearer_token_works(self):
-        url = f"{APIROOT}/{METADATA_FILE}"
+    def validate_bearer_token_works(self, url):
         global cookiejar
 
-        # Find the token
         token = None
+        # Find the token
         for cookie in cookiejar:
             # Find the 'asf-urs' cookie...
             if cookie.name == 'asf-urs':
                 # Grab the JWT payload:
                 cookie_b64 = cookie.value.split(".")[1]
                 # Fix the padding:
-                cookie_b64 += '='* (4 - (len(cookie_b64)%4))
+                cookie_b64 += '=' * (4 - (len(cookie_b64) % 4))
                 # Decode & Load...
                 cookie_json = json.loads(base64.b64decode(cookie_b64))
                 if 'urs-access-token' in cookie_json:
@@ -299,39 +297,20 @@ class authed_download_test(unittest.TestCase):
         self.assertTrue(token is not None)
 
         log.info(f"Attempting to download {url} using the token as a Bearer token")
-        r = requests.get(url, headers = {"Authorization": f"Bearer {token}"})
-
-        log.info(f"Bearer Token Download attempt Return Code: {r.status_code} (Expect 200)")
-        # FIXME: This should work, but not until its release into production
-        # self.assertEqual(r.status_code, 200)
-
-    def test_validate_bearer_access_private_fie(self):
-        url = f'{APIROOT}/PRIVATE/ACCESS/testfile'
-        global cookiejar
-
-        # Find the token
-        token = None
-        for cookie in cookiejar:
-            # Find the 'asf-urs' cookie...
-            if cookie.name == 'asf-urs':
-                # Grab the JWT payload:
-                cookie_b64 = cookie.value.split(".")[1]
-                # Fix the padding:
-                cookie_b64 += '='* (4 - (len(cookie_b64)%4))
-                # Decode & Load...
-                cookie_json = json.loads(base64.b64decode(cookie_b64))
-                if 'urs-access-token' in cookie_json:
-                    token = cookie_json['urs-access-token']
-
-        log.info(f"Make sure we were able to decode a token from the cookie: {token} (Expect not None)")
-        self.assertTrue(token is not None)
-
-        log.info(f"Attempting to download {url} using the token as a Bearer token")
-        r = requests.get(url, headers = {"Authorization": f"Bearer {token}"})
+        r = requests.get(url, headers={"Authorization": f"Bearer {token}"})
 
         log.info(f"Bearer Token Download attempt Return Code: {r.status_code} (Expect 200)")
         # FIXME: This should work, but not until its release into production
         self.assertEqual(r.status_code, 200)
+
+    # Validate EDL token works (if a little incestously)
+    def test_validate_bearer_token_works(self):
+        url = f"{APIROOT}/{METADATA_FILE}"
+        self.validate_bearer_token_works(url)
+
+    def test_validate_private_file_bearer_token_works(self):
+        url = f'{APIROOT}/PRIVATE/ACCESS/testfile'
+        self.validate_bearer_token_works(url)
 
 
 class jwt_blacklist_test(unittest.TestCase):

--- a/build/test/download_test.py
+++ b/build/test/download_test.py
@@ -279,7 +279,7 @@ class authed_download_test(unittest.TestCase):
                 cookie_json = json.loads(base64.b64decode(cookie_b64))
                 if 'urs-access-token' in cookie_json:
                     return cookie_json['urs-access-token']
-        return ''
+        return None
 
     def validate_bearer_token_works(self, url):
         token = self.find_bearer_token()

--- a/build/test/download_test.py
+++ b/build/test/download_test.py
@@ -217,7 +217,7 @@ class authed_download_test(unittest.TestCase):
 
         log.info(f"APPROVED Private File check: {r.status_code} (Expect 200)")
         self.assertTrue(r.status_code == 200)
-:
+
     def test_approved_user_cant_access_private_data(self):
         url = f"{APIROOT}/PRIVATE/NOACCESS/testfile"
         global cookiejar

--- a/build/test/download_test.py
+++ b/build/test/download_test.py
@@ -301,7 +301,6 @@ class authed_download_test(unittest.TestCase):
         r = requests.get(url, headers={"Authorization": f"Bearer {token}"})
 
         log.info(f"Bearer Token Download attempt Return Code: {r.status_code} (Expect 200)")
-        # FIXME: This should work, but not until its release into production
         self.assertEqual(r.status_code, 200)
 
     def test_validate_bearer_token_works(self):

--- a/build/test/download_test.py
+++ b/build/test/download_test.py
@@ -331,7 +331,7 @@ class authed_download_test(unittest.TestCase):
 
         log.info(f"Bearer Token Download attempt Return Code: {r.status_code} (Expect 200)")
         # FIXME: This should work, but not until its release into production
-        # self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.status_code, 200)
 
 
 class jwt_blacklist_test(unittest.TestCase):

--- a/build/test/download_test.py
+++ b/build/test/download_test.py
@@ -120,7 +120,6 @@ class unauthed_download_test(unittest.TestCase):
         log.info(f'Public prefix in restricted bucket {url} Return Code: {r.status_code} (Expect 200)')
         self.assertTrue(r.status_code == 200)
 
-    # Check for 404 on bad request
     def test_404_on_bad_request(self):
         url = f"{APIROOT}/bad/url.ext"
         r = requests.get(url)
@@ -128,7 +127,6 @@ class unauthed_download_test(unittest.TestCase):
         log.info(f"Checking that a non-existent file ({url}) returns a 404: r.status_code (Expect 404)")
         self.assertTrue(r.status_code == 404)
 
-    # Check that a bad cookie value causes URS redirect:
     def test_bad_cookie_value_cause_URS_redirect(self):
         url = f"{APIROOT}/{METADATA_FILE}"
         cookies = {'urs_user_id': "badusername", 'urs_access_token': "blah"}
@@ -147,7 +145,6 @@ class unauthed_download_test(unittest.TestCase):
 
 
 class auth_download_test(unittest.TestCase):
-    # Validate that auth process is successful
     def test_auth_process_is_successful(self):
         url = f"{APIROOT}/{METADATA_FILE}"
         global cookiejar
@@ -177,7 +174,6 @@ class auth_download_test(unittest.TestCase):
         self.assertTrue(final_request.status_code == 200)
 
 class authed_download_test(unittest.TestCase):
-    # Check that we get a URS auth redirect for auth'd downloads
     def test_urs_auth_redirect_for_auth_downloads(self):
         url = f"{APIROOT}/{METADATA_FILE}"
         global cookiejar
@@ -197,7 +193,6 @@ class authed_download_test(unittest.TestCase):
         log.info(f"Make sure 'Location' header is not redirecting to URS")
         self.assertTrue('oauth/authorize' not in r.headers['Location'])
 
-    # Check that range requests work
     def test_range_request_works(self):
         url = f"{APIROOT}/{METADATA_FILE}"
         headers = {"Range": "bytes=1035-1042"}
@@ -213,7 +208,6 @@ class authed_download_test(unittest.TestCase):
         log.info(f"Range Data: {r.text}")
         self.assertTrue(len(r.text) == 8)
 
-    # Check that approved users can access PRIVATE data:
     def test_approved_user_can_access_private_data(self):
         url = f'{APIROOT}/PRIVATE/ACCESS/testfile'
         global cookiejar
@@ -223,8 +217,7 @@ class authed_download_test(unittest.TestCase):
 
         log.info(f"APPROVED Private File check: {r.status_code} (Expect 200)")
         self.assertTrue(r.status_code == 200)
-
-    # Check that approved users CAN'T access PRIVATE data they don't have access to:
+:
     def test_approved_user_cant_access_private_data(self):
         url = f"{APIROOT}/PRIVATE/NOACCESS/testfile"
         global cookiejar
@@ -235,7 +228,6 @@ class authed_download_test(unittest.TestCase):
         log.info(f"UNAPPROVED Private File check: {r.status_code} (Expect 403)")
         self.assertTrue(r.status_code == 403)
 
-    # Validating objects with prefix, works
     def test_validating_objects_with_prefix(self):
         url = f"{APIROOT}/SA/BROWSE/dir1/dir2/deepfile.txt"
         global cookiejar
@@ -249,7 +241,6 @@ class authed_download_test(unittest.TestCase):
         log.info(f"Pre-fixed object Return Code: {r.status_code} (Expect 200)")
         self.assertTrue(r.status_code == 200)
 
-    # Validating custom headers
     def test_validate_custom_headers(self):
         url = f"{APIROOT}/{METADATA_FILE_CH}"
         header_name = 'x-rainheader1'
@@ -263,7 +254,6 @@ class authed_download_test(unittest.TestCase):
         log.info(f"{header_name} had value '{header_value}' (Expect 'rainheader1 value')")
         self.assertTrue(r.headers.get(header_name) is not None)
 
-    # Validate /locate handles complex configuration keys
     def test_validate_locate_handles_complex_configuration_key(self):
         url = f"{APIROOT}/locate?bucket_name={LOCATE_BUCKET}"
         global cookiejar

--- a/build/test/download_test.py
+++ b/build/test/download_test.py
@@ -276,13 +276,10 @@ class authed_download_test(unittest.TestCase):
         paths = sorted(json.loads(r.content))
         self.assertEqual(paths, MAP_PATHS)
 
-    def validate_bearer_token_works(self, url):
+    @staticmethod
+    def find_bearer_token():
         global cookiejar
-
-        token = None
-        # Find the token
         for cookie in cookiejar:
-            # Find the 'asf-urs' cookie...
             if cookie.name == 'asf-urs':
                 # Grab the JWT payload:
                 cookie_b64 = cookie.value.split(".")[1]
@@ -291,7 +288,11 @@ class authed_download_test(unittest.TestCase):
                 # Decode & Load...
                 cookie_json = json.loads(base64.b64decode(cookie_b64))
                 if 'urs-access-token' in cookie_json:
-                    token = cookie_json['urs-access-token']
+                    return cookie_json['urs-access-token']
+        return ''
+
+    def validate_bearer_token_works(self, url):
+        token = self.find_bearer_token()
 
         log.info(f"Make sure we were able to decode a token from the cookie: {token} (Expect not None)")
         self.assertTrue(token is not None)
@@ -303,7 +304,6 @@ class authed_download_test(unittest.TestCase):
         # FIXME: This should work, but not until its release into production
         self.assertEqual(r.status_code, 200)
 
-    # Validate EDL token works (if a little incestously)
     def test_validate_bearer_token_works(self):
         url = f"{APIROOT}/{METADATA_FILE}"
         self.validate_bearer_token_works(url)

--- a/lambda/app.py
+++ b/lambda/app.py
@@ -650,6 +650,7 @@ def dynamic_url():
             jwt_payload = user_profile_2_jwt_payload(user_id, token, user_profile)
             log.debug(f"Encoding JWT_PAYLOAD: {jwt_payload}")
             custom_headers.update(make_set_cookie_headers_jwt(jwt_payload, '', os.getenv('COOKIE_DOMAIN', '')))
+            cookievars[JWT_COOKIE_NAME] = jwt_payload
 
         else:
             return do_auth_and_return(app.current_request.context)


### PR DESCRIPTION
Fix to [issue](https://github.com/asfadmin/rain-api-core/issues/137)