### PR TITLE
Update TEA Lambda to attempt to reduce CIDR range

### DIFF
--- a/lambda/update_lambda.py
+++ b/lambda/update_lambda.py
@@ -2,7 +2,7 @@ import json
 import boto3
 import urllib.request
 import os
-
+from netaddr import cidr_merge
 import cfnresponse
 
 
@@ -57,6 +57,8 @@ def get_region_cidrs(current_region):
     ip_ranges = json.loads(output)['prefixes']
     in_region_amazon_ips = [item['ip_prefix'] for item in ip_ranges if
                             item["service"] == "AMAZON" and item["region"] == current_region]
+    # It's important to filter down the CIDR range as much as possible. Too large can cause the role creation to fail.
+    in_region_amazon_ips = [str(ip) for ip in cidr_merge(in_region_amazon_ips)]
     # Add in Privagte IP Space
     in_region_amazon_ips.append('10.0.0.0/8')
     return (in_region_amazon_ips)


### PR DESCRIPTION
This change came about because the "DownloadRoleInRegion" lambda update was failing to properly update, complaining that the role size was too big.

We were deploying in us-east-1, so the CIDR range fetched was about 799 addresses.
With cidr_merge it got it down to about 449, or saving about 6000 bytes on the role.

This should allow the role policy document to be adequately created for now. It will also dynamically adjust as AWS changes their IP list.

Resubmitting because it was supposed to branch off devel and not master.