### PR TITLE
PR-3041 Update dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,8 @@
-aws-requests-auth==0.4.3
 cachetools==5.0.0
 cfnresponse==1.1.1
 chalice==1.26.2
-cryptography==35.0.0
 flatdict==4.0.1
 git+https://github.com/asfadmin/rain-api-core.git@f07a0ca637033d96fdd080d78439d6413ba2b14b
-jinja2==3.0.2
-jwcrypto==1.0
 netaddr==0.8.0
-pyjwt==2.3.0
-pyOpenSSL==21.0.0 # maybe not necessary
-python-jose==3.3.0
-PyYAML==6.0
 
 pip>=19.2 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 cachetools==5.0.0
-cfnresponse==1.1.1
-chalice==1.26.2
+cfnresponse==1.1.2
+chalice==1.26.5
 flatdict==4.0.1
-git+https://github.com/asfadmin/rain-api-core.git@f07a0ca637033d96fdd080d78439d6413ba2b14b
+git+https://github.com/asfadmin/rain-api-core.git@17f5e026749da048553fab825543cbf76c8a4f77
 netaddr==0.8.0
 
 pip>=19.2 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
Might be a good idea to pin dependency versions with `pip-tools` or `pipenv`. These tools will automatically pin the entire dependency tree in order to produce deterministic builds. They also both provide a single command upgrade mechanism to pin everything to the latest version.