### PR TITLE
PR-3033 Add a makefile for automating development tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ terraform.tfstate*
 
 # Config
 bucket_map.yaml
+CONFIG
 
 # Other
 /pkg

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ bucket_map.yaml
 /pkg
 build/requirements_dev.txt
 build/tea-dev.Dockerfile
+dist

--- a/CONFIG.example
+++ b/CONFIG.example
@@ -16,6 +16,8 @@ CODE_PREFIX = $(STACK_NAME)/
 CONFIG_BUCKET = REQUIRED!
 # Object prefix for artifacts in the config bucket
 CONFIG_PREFIX = $(STACK_NAME)/
+# Uncomment the following line to use an existing bucket map rather than uploading one
+# BUCKET_MAP_OBJECT_KEY =
 
 # String that will be prepended to bucket names after looking them up in the bucket map
 BUCKETNAME_PREFIX =

--- a/CONFIG.example
+++ b/CONFIG.example
@@ -1,0 +1,50 @@
+##############
+# TEA config #
+##############
+
+# The name of the CloudFormation stack to deploy to.
+# For development, this should be a constant value. If code is changed the
+# stack will be updated with the new zip files.
+STACK_NAME = thin-egress-app-dev
+
+# S3 bucket that will contain the build artifacts
+CODE_BUCKET = REQUIRED!
+# Object prefix for artifacts in the code bucket
+CODE_PREFIX = $(STACK_NAME)/
+
+# S3 bucket that will contain the configuration files such as the bucket map
+CONFIG_BUCKET = REQUIRED!
+# Object prefix for artifacts in the config bucket
+CONFIG_PREFIX = $(STACK_NAME)/
+
+# String that will be prepended to bucket names after looking them up in the bucket map
+BUCKETNAME_PREFIX =
+
+# These secrets are required but not managed by the Makefile.
+# For full deployments use `build/deploy.sh`
+JWT_KEY_SECRET_NAME = REQUIRED!
+URS_CREDS_SECRET_NAME = REQUIRED!
+
+# EarthData Login base URL
+URS_URL = https://uat.urs.earthdata.nasa.gov
+
+##################
+# AWS cli config #
+##################
+
+# AWS cli binary name
+AWS = aws
+
+# AWS profile to use
+AWS_PROFILE = default
+
+########
+# Misc #
+########
+
+# Supported JWT algorithm
+JWTALGO = RS256
+
+# AWS Lambda
+LAMBDA_TIMEOUT = 6
+LAMBDA_MEMORY = 128

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,107 @@
+# TODO(reweeden): docs
+SOURCES = \
+	lambda/app.py \
+	lambda/tea_bumper.py \
+	lambda/update_lambda.py
+
+RESOURCES = \
+	lambda/templates
+
+DIST = $(SOURCES:lambda=dist/code)
+DIST_RESOURCES = $(RESOURCES:lambda=dist/code)
+
+CODE_BUCKET =
+CODE_DIR = tea-dev
+
+AWS_PROFILE = default
+AWS_DEFAULT_REGION = us-west-2
+
+JWTALGO = RS256
+JWTKEYSECRETNAME = bbarton_rsa_keys_4_jwt
+LAMBDA_TIMEOUT = 6
+LAMBDA_MEMORY = 128
+URS_URL = https://uat.urs.earthdata.nasa.gov
+URS_CREDS_SECRET_NAME = URS_creds_ASF_DATA_ACCESS_EGRESS_CONTROL_UAT
+BUCKETNAME_PREFIX = rain-uw2-t-
+
+BUILD_ID := $(shell git rev-parse --short HEAD)
+
+.PHONY: build clean default deploy deploy-dependencies deploy-code deploy-cloudformation layer-builder test
+
+default:
+	@echo "WIP"
+	@echo "BUILD_ID: ${BUILD_ID}"
+
+build: dist/code-$(BUILD_ID).zip dist/dependencies-$(BUILD_ID).zip dist/thin-egress-app-$(BUILD_ID).yaml
+
+clean:
+	rm -r dist
+
+dist/thin-egress-app-$(BUILD_ID).yaml: cloudformation/thin-egress-app.yaml
+	mkdir -p dist
+	cp cloudformation/thin-egress-app.yaml dist/thin-egress-app-$(BUILD_ID).yaml
+	sed -i -e "s/asf.public.code/${CODE_BUCKET}/" dist/thin-egress-app-$(BUILD_ID).yaml
+	sed -i -e "s/<CODE_ARCHIVE_PATH_FILENAME>/${CODE_DIR}\\/code-${BUILD_ID}.zip/" dist/thin-egress-app-$(BUILD_ID).yaml
+	sed -i -e "s/<DEPENDENCY_ARCHIVE_PATH_FILENAME>/${CODE_DIR}\\/dependencies-${BUILD_ID}.zip/" dist/thin-egress-app-$(BUILD_ID).yaml
+	sed -i -e "s/<BUILD_ID>/${BUILD_ID}/g" dist/thin-egress-app-$(BUILD_ID).yaml
+	sed -i -e "s/^Description:.*/Description: \"TEA snapshot, version: ${BUILD_ID}\"/" dist/thin-egress-app-$(BUILD_ID).yaml
+
+dist/code-$(BUILD_ID).zip: $(DIST) $(DIST_RESOURCES)
+	mkdir -p dist/code
+	cp -r $(DIST) dist/code
+	cp -r $(DIST_RESOURCES) dist/code
+	find dist/code -type f -exec sed -i "s/<BUILD_ID>/${BUILD_ID}/g" {} \;
+	cd dist/code && zip -r ../code-$(BUILD_ID).zip .
+
+dist/dependencies-$(BUILD_ID).zip: requirements.txt
+	mkdir -p dist
+	WORKSPACE=`pwd` DEPENDENCYLAYERFILENAME=dist/dependencies-$(BUILD_ID).zip build/dependency_builder.sh
+
+deploy-dependencies: dist/dependencies-$(BUILD_ID).zip
+	aws s3 cp --profile=$(AWS_PROFILE) dist/dependencies-$(BUILD_ID).zip s3://$(CODE_BUCKET)/$(CODE_DIR)/dependencies-$(BUILD_ID).zip
+
+deploy-code: dist/code-$(BUILD_ID).zip
+	aws s3 cp --profile=$(AWS_PROFILE) dist/code-$(BUILD_ID).zip s3://$(CODE_BUCKET)/$(CODE_DIR)/code-$(BUILD_ID).zip
+
+deploy-cloudformation: dist/thin-egress-app-$(BUILD_ID).yaml
+	aws cloudformation deploy --region=$(AWS_DEFAULT_REGION) \
+						 --stack-name thin-egress-app-$(BUILD_ID) \
+						 --template-file dist/thin-egress-app-$(BUILD_ID).yaml \
+						 --capabilities CAPABILITY_NAMED_IAM \
+						 --parameter-overrides \
+							 URSAuthCredsSecretName=$(URS_CREDS_SECRET_NAME) \
+							 AuthBaseUrl=$(URS_URL) \
+							 ConfigBucket=$(BUCKETNAME_PREFIX)config \
+							 PermissionsBoundaryName= \
+							 BucketMapFile=bucket_map_customheaders.yaml \
+							 PublicBucketsFile="" \
+							 PrivateBucketsFile="" \
+							 BucketnamePrefix=$(BUCKETNAME_PREFIX) \
+							 DownloadRoleArn="" \
+							 DownloadRoleInRegionArn="" \
+							 HtmlTemplateDir= \
+							 StageName=API \
+							 Loglevel=DEBUG \
+							 Logtype=json \
+							 Maturity=DEV\
+							 PrivateVPC= \
+							 VPCSecurityGroupIDs= \
+							 VPCSubnetIDs= \
+							 EnableApiGatewayLogToCloudWatch="False" \
+							 DomainName=$(DOMAIN_NAME-"") \
+							 DomainCertArn=$(DOMAIN_CERT_ARN-"")  \
+							 CookieDomain=$(COOKIE_DOMAIN-"") \
+							 LambdaTimeout=$(LAMBDA_TIMEOUT) \
+							 LambdaMemory=$(LAMBDA_MEMORY) \
+							 JwtAlgo=$(JWTALGO) \
+							 JwtKeySecretName=$(JWTKEYSECRETNAME) \
+							 UseReverseBucketMap="False" \
+							 UseCorsCookieDomain="False"
+
+deploy: deploy-dependencies deploy-code deploy-cloudformation
+
+layer-builder:
+	docker build -t layer-builder -f build/dependency_layer_builder.Dockerfile build
+
+test:
+	pytest --cov=lambda --cov-report=term-missing --cov-branch tests

--- a/README.MD
+++ b/README.MD
@@ -195,65 +195,76 @@ builds and code cannot be released without all tests completing successfully.
 
 ### Roll-Your-Own
 
-If you prefer to roll your own zip for the lambda code:
+If you prefer to roll your own zip for the lambda code you can use our Makefile to build it
+from source in a bash environment. You will need to have a few tools installed for this to work:
+
+- `zip` for creating zip files
+- `pip` for building the dependency layer
+- `awscli` (optional) for deploying to AWS
+
+All build artifacts are created into the `dist` directory.
+```bash
+# Creates the lambda code zip: dist/thin-egress-app-code.zip
+make code
+# Creates the dependnecy layer zip: dist/thin-egress-app-dependencies.zip
+make dependencies
+# Creates the CloudFormation template: dist/thin-egress-app.yaml
+make yaml
+
+# Creates all three
+make build
+```
+
+You can deploy these artifacts to a development stack with
+```bash
+make deploy
+```
+*Note: You can run this command as many times as you like, make will automatically detect
+changes made to the source code and rebuild/update the stack as needed*
+
+#### Configuration
+After you run any `make` command, you will notice a file called `CONFIG`. This contains any Make
+configuration variables that you may wish to tweak for your development purposes. If you need to
+override any additional variables from the Makefile you can put them in this file. Alternatively,
+if you just need to make a one off change, `make` lets you set variables on the command line:
+
+```bash
+make deploy STACK_NAME=thin-egress-app-temp AWS_PROFILE=development
+```
+
+You will need to change any variables that have the value `REQUIRED!` before you can run
+`make deploy`.
 
 #### Dependency Layer
-We've found that if the dependency layer isn't built in an `amazonlinux:2` environment, the JWT crypto doesn't work. Here are instructions for gathering and packaging the dependencies in an `amazonlinux` docker container.
+
 ```bash
-
-# Make up a filename for code archive:
-DEPENDENCYLAYERFILENAME=tea_depencency_layer.zip
-
 # get the repo
 git clone https://github.com/asfadmin/thin-egress-app
 cd thin-egress-app
 
-# copy requirements to a directory that is mounted into the docker container
-cp lambda/requirements.txt lambda/requirements_tea.txt
-cp build/dependency_builder.sh lambda/
-
-docker run --rm -v lambda/:/depbuild/in -v ./:/depbuild/out -e "ZIPFILENAME=${DEPENDENCYLAYERFILENAME}" amazonlinux:2  bash /depbuild/in/dependency_builder.sh
+# Build the zip file
+make dependencies
 
 # Upload to S3
-aws s3 cp --profile=default ./${DEPENDENCYLAYERFILENAME} s3://${CODE_BUCKET}/
+aws s3 cp --profile=default dist/thin-egress-app-dependencies.zip s3://${CODE_BUCKET}/
 ```
+
+*Note: If you are expecting the `cryptography` dependency to be built from source, you may need to
+run these commands in an `amazonlinux:2` docker container. However, as `cryptography` distributes
+`manylinux` wheels, this should not be necessary*
 
 #### Packaging up the egress code:
 
 ```bash
-
-# Make up a filename for code archive:
-CODE_ARCHIVE_FILENAME=thin-egress-app-code.zip
-
-# get the repo
+# Get the repo
 git clone https://github.com/asfadmin/thin-egress-app
 cd thin-egress-app
 
-# Create a scratch directory in which to confine the required module
-
-# To make the archive smaller, you can cull unnecessary packages and files from the directory. The particulars
-# are beyond the scope of this documentation.
-
-# Create the zip archive and put the required modules in
-zip -r9 ./${CODE_ARCHIVE_FILENAME} ./lambda
-
-# Add the egress python code
-zip -g ./${CODE_ARCHIVE_FILENAME} ./app.py
-
-# Add the update lambda
-zip -g ./${CODE_ARCHIVE_FILENAME} ./update_lambda.py
-
-# Add the html templates
-zip -g -r2 ./${CODE_ARCHIVE_FILENAME} ./templates
-
-# Add the common code:
-cd rain_api_core
-zip -g -r9 ./${CODE_ARCHIVE_FILENAME} ./rain_api_core
-cd ..
+# Build the zip file
+make code
 
 # Upload to S3
-aws s3 cp --profile=default ./${CODE_ARCHIVE_FILENAME} s3://${CODE_BUCKET}/
-
+aws s3 cp --profile=default dist/thin-egress-app-code.zip s3://${CODE_BUCKET}/
 ```
 
 [⬆ Return to Table of Contents](#table-of-contents)

--- a/build/dependency_builder.sh
+++ b/build/dependency_builder.sh
@@ -29,14 +29,11 @@ python3.8 -m pip install -r "${WORKSPACE}"/requirements.txt --target .
 
 # get rid of unneeded things to make code zip smaller
 rm -rf ./*.dist-info
-# rm -rf pip # commented out because https://snyk.io/vuln/SNYK-PYTHON-PIP-609855
 rm -rf docutils
-rm -rf chalice/cli # cli in lambda? No way!
+rm -rf click chalice/cli # cli in lambda? No way!
 rm -rf botocore # included with lambda, just takes up space here
-rm -rf setuptools
+rm -rf pip setuptools wheel easy_install.py
 rm -rf tests
-rm -rf easy_install.py
-rm -f typing.py # MUST be removed, its presence causes error every time
 
 cd ..
 # now in pkg/

--- a/build/dependency_builder.sh
+++ b/build/dependency_builder.sh
@@ -13,7 +13,6 @@ yum install -y amazon-linux-extras && \
 amazon-linux-extras enable python3.8
 
 yum install -y zip git python38 python38-pip
-python3.8 -m pip install --upgrade pip
 yum clean all
 
 mkdir -p /tmp/pkg/python

--- a/build/dependency_builder.sh
+++ b/build/dependency_builder.sh
@@ -7,25 +7,25 @@
 echo "RUNNING dependency_builder.sh"
 
 echo "inside dependency building container env:"
-printenv
-
-yum install -y amazon-linux-extras && \
-amazon-linux-extras enable python3.8
-
-yum install -y zip git python38 python38-pip
-yum clean all
+# printenv
+#
+# yum install -y amazon-linux-extras && \
+# amazon-linux-extras enable python3.8
+#
+# yum install -y zip git python38 python38-pip
+# yum clean all
 
 mkdir -p /tmp/pkg/python
 
 
 cd /tmp/pkg/python || exit
 
-echo "Updating Pip..."
-python3.8 -m pip install -U pip
+# echo "Updating Pip..."
+# python3.8 -m pip install -U pip
 echo "Installing setuptools..."
-python3.8 -m pip install --upgrade setuptools
+# python3.8 -m pip install --upgrade setuptools
 echo "Installing ${WORKSPACE}/requirements.txt"
-python3.8 -m pip install -r "${WORKSPACE}"/requirements.txt --target .
+python3.8 -m pip install --upgrade -r "${WORKSPACE}/requirements.txt" --target .
 
 # get rid of unneeded things to make code zip smaller
 rm -rf ./*.dist-info

--- a/config/bucket-map-template.yaml
+++ b/config/bucket-map-template.yaml
@@ -1,0 +1,7 @@
+MAP:
+# See examples
+#   BROWSE:
+#     PLATFORM-A: platform-a-bucket
+#
+# PUBLIC_BUCKETS:
+#   - platform-a-bucket

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ cachetools==5.0.0
 cfnresponse==1.1.2
 chalice==1.26.5
 flatdict==4.0.1
-git+https://github.com/asfadmin/rain-api-core.git@17f5e026749da048553fab825543cbf76c8a4f77
+git+https://github.com/asfadmin/rain-api-core.git@42032ec569a60b4ac9672f4faa81e41b8f6eef27
 netaddr==0.8.0
 
 pip>=19.2 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
I've been writing the Makefile with a focus mostly on development tasks plus producing all build artifacts. It can deploy a development stack minus secrets, and due to the magic of Make will update the relevant portions when you make changes to the code. For instance if you edit the `app.py` and then run `make deploy` it will rebuild the lambda code zip file, upload it to S3 and update the CloudFormation stack. If you then edit the requirements.txt and run `make deploy` again it will rebuild the dependency layer zip file, upload it to S3 and update the CloudFormation stack. This means it takes round about 1 minute from making a local change to having it take effect on your development stack.


TODO: 
- Use Makefile in Jenkins
- Document how to run the unit tests in a virtual environment
- Resolve TODO's ;)