### PR TITLE
Compile pattern in multiline mode

### DIFF
--- a/scripts/sed.py
+++ b/scripts/sed.py
@@ -20,7 +20,7 @@ def substitute(pattern, replacement, buf_in, buf_out):
 
 def pattern(arg):
     try:
-        return re.compile(arg)
+        return re.compile(arg, flags=re.MULTILINE)
     except re.error:
         raise ValueError()
 


### PR DESCRIPTION
The template description was not being replaced because `^` was only matching the beginning of the file.