### PR TITLE
Improve support for building local dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ DOCKER := docker
 # On Linux we need to do a bit of userid finagling so that the output files
 # end up being owned by us and not by root. On Mac this works out of the box.
 DOCKER_USER_ARG := --user "$(shell id -u):$(shell id -g)"
-DOCKER_COMMAND := $(DOCKER) run --rm $(DOCKER_USER_ARG) -v "$$PWD":/var/task lambci/lambda:build-python3.8
+DOCKER_COMMAND = $(DOCKER) run --rm $(DOCKER_USER_ARG) -v "$$PWD":/var/task $(DOCKER_ARGS) lambci/lambda:build-python3.8
 
 #####################
 # Deployment Config #
@@ -84,7 +84,7 @@ terraform: $(DIR)/thin-egress-app-terraform.zip
 clean:
 	rm -rf $(DIR)
 
-$(DIR)/thin-egress-app-dependencies.zip: requirements.txt
+$(DIR)/thin-egress-app-dependencies.zip: requirements.txt $(REQUIREMENTS_DEPS)
 	rm -rf $(DIR)/python
 	@mkdir -p $(DIR)/python
 	$(DOCKER_COMMAND) build/dependency_builder.sh "$(DIR)/thin-egress-app-dependencies.zip" "$(DIR)"

--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ $(EMPTY)/.deploy-stack: $(DIR)/thin-egress-app.yaml $(EMPTY)/.deploy-dependencie
 					HtmlTemplateDir= \
 					StageName=API \
 					Loglevel=DEBUG \
-					Logtype=json \
+					Logtype=$(LOG_TYPE) \
 					Maturity=DEV\
 					PrivateVPC= \
 					VPCSecurityGroupIDs= \

--- a/Makefile
+++ b/Makefile
@@ -194,8 +194,6 @@ $(EMPTY)/.deploy-stack: $(DIR)/thin-egress-app.yaml $(EMPTY)/.deploy-dependencie
 					ConfigBucket=$(CONFIG_BUCKET) \
 					LambdaCodeS3Bucket=$(CODE_BUCKET) \
 					PermissionsBoundaryName= \
-					PublicBucketsFile="" \
-					PrivateBucketsFile="" \
 					BucketnamePrefix=$(BUCKETNAME_PREFIX) \
 					DownloadRoleArn="" \
 					DownloadRoleInRegionArn="" \

--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -67,8 +67,14 @@ AWS_PROFILE := default
 ########
 # Misc #
 ########
+# Add any local dependencies here that are required for the dependency layer to be built.
+# You will likely also need to add a volume mapping to DOCKER_ARGS or configure the
+# dependency layer build to run on the host (see below) for it to work properly.
+REQUIREMENTS_DEPS :=
 # Uncomment the following line to build the dependencies on the host (without docker)
 # DOCKER_COMMAND :=
+# Any additional arguments for the docker command
+DOCKER_ARGS :=
 
 # Supported JWT algorithm
 JWTALGO := RS256

--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -39,6 +39,9 @@ URS_CREDS_SECRET_NAME := REQUIRED_FOR_DEPLOY!
 # EarthData Login base URL
 URS_URL := https://uat.urs.earthdata.nasa.gov
 
+# Logging style, either `flat` for human readable or `json` for machine readable
+LOG_TYPE := flat
+
 ####################################
 # CloudFormation Template Defaults #
 ####################################

--- a/README.MD
+++ b/README.MD
@@ -296,6 +296,27 @@ make code
 aws s3 cp --profile=default dist/thin-egress-app-code.zip s3://${CODE_BUCKET}/
 ```
 
+#### Configuring local pip dependencies
+If you need to build against a local version of one of the requirements in the `requirements.txt`
+such as `rain_api_core`, you will need to make a few adjustments to your `Makefile.config` for the
+docker container to be able to install those dependencies.
+
+1. Mount the local dependency as a docker volume using `DOCKER_ARGS` in your `Makefile.config`:
+```makefile
+DOCKER_ARGS := -v /host/path/to/rain-api-core:/var/task/rain-api-core
+```
+2. Add the container path to the `requirements.txt` file:
+```
+file:/var/task/rain-api-core
+```
+3. Add any source files of that dependency to the `REQUIREMENTS_DEPS` in your `Makefile.config`:
+```makefile
+REQUIREMENTS_DEPS := $(shell find /host/path/to/rain-api-core/rain_api_core/ -name '*.py')
+```
+
+Now when you run `make build`, the dependency layer should be correctly rebuilt if any of the
+source files in your local version of the dependency have changed.
+
 [⬆ Return to Table of Contents](#table-of-contents)
 
 ## Getting TEA Code

--- a/build/Jenkinsfile
+++ b/build/Jenkinsfile
@@ -194,8 +194,6 @@ pipeline {
                            ConfigBucket=${BUCKETNAME_PREFIX}config \
                            PermissionsBoundaryName= \
                            BucketMapFile=bucket_map_customheaders.yaml \
-                           PublicBucketsFile="" \
-                           PrivateBucketsFile="" \
                            BucketnamePrefix=${BUCKETNAME_PREFIX} \
                            DownloadRoleArn="" \
                            DownloadRoleInRegionArn="" \
@@ -232,8 +230,6 @@ pipeline {
                            ConfigBucket=rain-t-config \
                            PermissionsBoundaryName= \
                            BucketMapFile=bucket_map_customheaders.yaml \
-                           PublicBucketsFile="" \
-                           PrivateBucketsFile="" \
                            BucketnamePrefix=${BUCKETNAME_PREFIX_SCND} \
                            DownloadRoleArn=${DOWNLOAD_ROLE_ARN} \
                            DownloadRoleInRegionArn=${DOWNLOAD_ROLE_ARN_INREGION} \


### PR DESCRIPTION
Some changes I needed to do to be able to build TEA with a local development version of rain api core.