### PR TITLE
Add end-to-end tests for GDAL operations

### DIFF
--- a/.github/workflows/re-test-e2e.yml
+++ b/.github/workflows/re-test-e2e.yml
@@ -182,12 +182,16 @@ jobs:
                   VPCSecurityGroupIDs= \
                   VPCSubnetIDs=
 
+      - name: Install GDAL library
+        run: |
+          sudo apt-get install -y libgdal-dev
+
       - name: Run end to end tests
         env:
           URS_USERNAME: ${{ secrets.URS_USERNAME }}
           URS_PASSWORD: ${{ secrets.URS_PASSWORD }}
         run: |
-          pip install -r requirements-dev.txt
+          pip install -r requirements-dev.txt GDAL==3.0.4
           pytest tests_e2e \
               --stack-name=$STACK_NAME \
               --test-results=asf.public.code/thin-egress-app/testresults.json \

--- a/tests_e2e/test_gdal.py
+++ b/tests_e2e/test_gdal.py
@@ -1,0 +1,35 @@
+# Some common use cases that users might have for interacting with TEA data
+# through GDAL. In particular using the vsicurl driver.
+from http.cookiejar import MozillaCookieJar
+
+import pytest
+
+gdal = pytest.importorskip("osgeo.gdal")
+
+GRANULE = "S1A_IW_SLC__1SVV_20150604T161908_20150604T161939_006226_008216_5A4E"
+ZIP_FILE = f"{GRANULE}.zip"
+SAFE_FILE = f"{GRANULE}.SAFE"
+
+
+@pytest.fixture(autouse=True)
+def _config(tmp_path, auth_cookies):
+    cookie_file_name = str(tmp_path / "cookies.txt")
+
+    # Write the auth cookies to the file in a format that CURL can understand
+    cookiejar = MozillaCookieJar(cookie_file_name)
+    for cookie in auth_cookies:
+        cookiejar.set_cookie(cookie)
+    cookiejar.save()
+
+    gdal.UseExceptions()
+    gdal.SetConfigOption("GDAL_HTTP_COOKIEFILE", cookie_file_name)
+    gdal.SetConfigOption("GDAL_HTTP_COOKIEJAR", cookie_file_name)
+    gdal.SetConfigOption("GDAL_HTTP_MAX_RETRY", "0")
+    gdal.SetConfigOption("GDAL_DISABLE_READDIR_ON_OPEN", "TRUE")
+
+
+def test_list_zip_contents(urls):
+    url = urls.join("SA", "SLC", ZIP_FILE)
+    res = gdal.ReadDir(f"/vsizip/vsicurl/{url}")
+
+    assert res == [SAFE_FILE]

--- a/tests_e2e/test_public.py
+++ b/tests_e2e/test_public.py
@@ -73,8 +73,9 @@ def test_bad_cookie_value_cause_URS_redirect(urls):
 
 
 def test_head_private_data(urls):
-    # All files are publically headable!
+    # All files are publicly headable!
     # TODO(reweeden): Is this desired?
+    # - Used by disambiguator to find the right hostname for a file
     url = urls.join("PRIVATE", "ACCESS", "testfile")
 
     r = requests.head(url, allow_redirects=True)


### PR DESCRIPTION
It came up in a discussion about refactoring the HEAD route that there may be some use cases where the HEAD operation needs to be publicly accessible and that there had been some issues with certain GDAL functions in the past when the HEAD route wasn't working correctly.

I took an example from https://github.com/isce-framework/isce2/discussions/349 and converted it into an end to end test.