### PR TITLE
Fix failing tests

### DIFF
--- a/lambda/app.py
+++ b/lambda/app.py
@@ -693,7 +693,6 @@ def dynamic_url():
     timer = Timer()
     timer.mark("restore_bucket_vars()")
 
-    custom_headers = {}
     log.debug('attempting to GET a thing')
     restore_bucket_vars()
     log.debug(f'b_map: {b_map.bucket_map}')
@@ -728,6 +727,7 @@ def dynamic_url():
         headers = {}
         return make_html_response(template_vars, headers, 404, 'error.html')
 
+    custom_headers = dict(entry.headers)
     cookievars = get_cookie_vars(app.current_request.headers)
     user_profile = None
     if cookievars:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,10 @@ sys.modules["boto3"] = mock_boto3
 _ = importlib.import_module("lambda.app")
 _ = importlib.import_module("lambda.tea_bumper")
 
-logging.getLogger().setLevel(logging.DEBUG)
+root_logger = logging.getLogger()
+for handler in root_logger.handlers:
+    root_logger.removeHandler(handler)
+root_logger.setLevel(logging.DEBUG)
 
 RESOURCES_PATH = pathlib.Path(__file__).parent.joinpath("resources/").absolute()
 

--- a/tests/resources/bucket_map_example.yaml
+++ b/tests/resources/bucket_map_example.yaml
@@ -11,6 +11,17 @@ MAP:
   PRIVATE:
     PLATFORM-A:         pa-priv
     PLATFORM-B:         pb-priv
+  HEADERS:
+    BROWSE:
+      bucket: pa-bro
+      headers:
+        custom-header-1: custom-header-1-value
+        custom-header-2: custom-header-2-value
+    PRIVATE:
+      bucket: pa-priv
+      headers:
+        custom-header-3: custom-header-3-value
+        custom-header-4: custom-header-4-value
 
 PUBLIC_BUCKETS:
   - pa-bro

--- a/tests/resources/bucket_map_example.yaml
+++ b/tests/resources/bucket_map_example.yaml
@@ -5,12 +5,6 @@ MAP:
   DATA-TYPE-1:
     PLATFORM-A:         pa-dt1
     PLATFORM-B:         pb-dt1
-  DATA-TYPE-2:
-    PLATFORM-A:         pa-dt2
-    PLATFORM-B:         pb-dt2
-  DATA-TYPE-3:
-    PLATFORM-A:         pa-dt3
-    PLATFORM-B:         pb-dt3
   BROWSE:
     PLATFORM-A:         pa-bro
     PLATFORM-B:         pb-bro

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -979,7 +979,8 @@ def test_dynamic_url(
     resources,
     current_request
 ):
-    mock_try_download_from_bucket.return_value = chalice.Response(body="Mock response", headers={}, status_code=200)
+    MOCK_RESPONSE = mock.Mock()
+    mock_try_download_from_bucket.return_value = MOCK_RESPONSE
     with resources.open("bucket_map_example.yaml") as f:
         mock_get_yaml_file.return_value = yaml.full_load(f)
 
@@ -1000,9 +1001,7 @@ def test_dynamic_url(
         {"urs-user-id": "user_name"},
         {}
     )
-    assert response.body == "Mock response"
-    assert response.status_code == 200
-    assert response.headers == {}
+    assert response is MOCK_RESPONSE
 
 
 @mock.patch(f"{MODULE}.get_yaml_file", autospec=True)
@@ -1017,7 +1016,8 @@ def test_dynamic_url_public(
     resources,
     current_request
 ):
-    mock_try_download_from_bucket.return_value = chalice.Response(body="Mock response", headers={}, status_code=200)
+    MOCK_RESPONSE = mock.Mock()
+    mock_try_download_from_bucket.return_value = MOCK_RESPONSE
     with resources.open("bucket_map_example.yaml") as f:
         mock_get_yaml_file.return_value = yaml.full_load(f)
 
@@ -1028,9 +1028,7 @@ def test_dynamic_url_public(
     response = app.dynamic_url()
 
     mock_try_download_from_bucket.assert_called_once_with("gsfc-ngap-d-pa-bro", "OBJECT_2", None, {})
-    assert response.body == "Mock response"
-    assert response.status_code == 200
-    assert response.headers == {}
+    assert response is MOCK_RESPONSE
 
 
 @mock.patch(f"{MODULE}.get_yaml_file", autospec=True)
@@ -1049,7 +1047,8 @@ def test_dynamic_url_private(
     resources,
     current_request
 ):
-    mock_try_download_from_bucket.return_value = chalice.Response(body="Mock response", headers={}, status_code=200)
+    MOCK_RESPONSE = mock.Mock()
+    mock_try_download_from_bucket.return_value = MOCK_RESPONSE
     user_profile = {
         "urs-user-id": "user_name",
         "urs-access-token": "access_token",
@@ -1075,9 +1074,7 @@ def test_dynamic_url_private(
         user_profile,
         {"SET-COOKIE": "cookie"}
     )
-    assert response.body == "Mock response"
-    assert response.status_code == 200
-    assert response.headers == {}
+    assert response is MOCK_RESPONSE
 
 
 @mock.patch(f"{MODULE}.get_yaml_file", autospec=True)
@@ -1092,7 +1089,8 @@ def test_dynamic_url_public_within_private(
     current_request
 ):
     # TODO(reweeden): Make an end-to-end version of this test as well
-    mock_try_download_from_bucket.return_value = chalice.Response(body="Mock response", headers={}, status_code=200)
+    MOCK_RESPONSE = mock.Mock()
+    mock_try_download_from_bucket.return_value = MOCK_RESPONSE
     mock_get_yaml_file.return_value = {
         "MAP": {
             "FOO": "bucket"
@@ -1110,9 +1108,7 @@ def test_dynamic_url_public_within_private(
     response = app.dynamic_url()
 
     mock_try_download_from_bucket.assert_called_once_with("gsfc-ngap-d-bucket", "BROWSE/OBJECT_1", None, {})
-    assert response.body == "Mock response"
-    assert response.status_code == 200
-    assert response.headers == {}
+    assert response is MOCK_RESPONSE
 
 
 @mock.patch(f"{MODULE}.get_yaml_file", autospec=True)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1033,6 +1033,41 @@ def test_dynamic_url_public(
 
 @mock.patch(f"{MODULE}.get_yaml_file", autospec=True)
 @mock.patch(f"{MODULE}.try_download_from_bucket", autospec=True)
+@mock.patch(f"{MODULE}.get_cookie_vars", autospec=True)
+@mock.patch(f"{MODULE}.JWT_COOKIE_NAME", "asf-cookie")
+@mock.patch(f"{MODULE}.b_map", None)
+def test_dynamic_url_public_custom_headers(
+    mock_get_cookie_vars,
+    mock_try_download_from_bucket,
+    mock_get_yaml_file,
+    resources,
+    current_request
+):
+    MOCK_RESPONSE = mock.Mock()
+    mock_try_download_from_bucket.return_value = MOCK_RESPONSE
+    with resources.open("bucket_map_example.yaml") as f:
+        mock_get_yaml_file.return_value = yaml.full_load(f)
+
+    mock_get_cookie_vars.return_value = {}
+    current_request.uri_params = {"proxy": "HEADERS/BROWSE/OBJECT_1"}
+
+    # Can't use the chalice test client here as it doesn't seem to understand the `{proxy+}` route
+    response = app.dynamic_url()
+
+    mock_try_download_from_bucket.assert_called_once_with(
+        "gsfc-ngap-d-pa-bro",
+        "OBJECT_1",
+        None,
+        {
+            "custom-header-1": "custom-header-1-value",
+            "custom-header-2": "custom-header-2-value"
+        }
+    )
+    assert response is MOCK_RESPONSE
+
+
+@mock.patch(f"{MODULE}.get_yaml_file", autospec=True)
+@mock.patch(f"{MODULE}.try_download_from_bucket", autospec=True)
 @mock.patch(f"{MODULE}.user_in_group", autospec=True)
 @mock.patch(f"{MODULE}.get_cookie_vars", autospec=True)
 @mock.patch(f"{MODULE}.make_set_cookie_headers_jwt", autospec=True)
@@ -1073,6 +1108,56 @@ def test_dynamic_url_private(
         "OBJECT_2",
         user_profile,
         {"SET-COOKIE": "cookie"}
+    )
+    assert response is MOCK_RESPONSE
+
+
+@mock.patch(f"{MODULE}.get_yaml_file", autospec=True)
+@mock.patch(f"{MODULE}.try_download_from_bucket", autospec=True)
+@mock.patch(f"{MODULE}.user_in_group", autospec=True)
+@mock.patch(f"{MODULE}.get_cookie_vars", autospec=True)
+@mock.patch(f"{MODULE}.make_set_cookie_headers_jwt", autospec=True)
+@mock.patch(f"{MODULE}.JWT_COOKIE_NAME", "asf-cookie")
+@mock.patch(f"{MODULE}.b_map", None)
+def test_dynamic_url_private_custom_headers(
+    mock_make_set_cookie_headers_jwt,
+    mock_get_cookie_vars,
+    mock_user_in_group,
+    mock_try_download_from_bucket,
+    mock_get_yaml_file,
+    resources,
+    current_request
+):
+    MOCK_RESPONSE = mock.Mock()
+    mock_try_download_from_bucket.return_value = MOCK_RESPONSE
+    user_profile = {
+        "urs-user-id": "user_name",
+        "urs-access-token": "access_token",
+        "first_name": "First",
+        "last_name": "Last",
+        "email_address": "user@example.com",
+        "user_groups": []
+    }
+    mock_make_set_cookie_headers_jwt.return_value = {"SET-COOKIE": "cookie"}
+    mock_user_in_group.return_value = (True, user_profile)
+    with resources.open("bucket_map_example.yaml") as f:
+        mock_get_yaml_file.return_value = yaml.full_load(f)
+
+    mock_get_cookie_vars.return_value = {"asf-cookie": user_profile}
+    current_request.uri_params = {"proxy": "HEADERS/PRIVATE/OBJECT_1"}
+
+    # Can't use the chalice test client here as it doesn't seem to understand the `{proxy+}` route
+    response = app.dynamic_url()
+
+    mock_try_download_from_bucket.assert_called_once_with(
+        "gsfc-ngap-d-pa-priv",
+        "OBJECT_1",
+        user_profile,
+        {
+            "custom-header-3": "custom-header-3-value",
+            "custom-header-4": "custom-header-4-value",
+            "SET-COOKIE": "cookie"
+        }
     )
     assert response is MOCK_RESPONSE
 

--- a/tests_e2e/conftest.py
+++ b/tests_e2e/conftest.py
@@ -12,6 +12,17 @@ logging.getLogger().setLevel(logging.DEBUG)
 logging.getLogger("botocore").setLevel(logging.INFO)
 
 
+def get_env(key):
+    """Helper to prevent environment from being printed"""
+    __tracebackhide__ = True
+    val = os.environ.get(key)
+
+    if val is None:
+        raise KeyError(key)
+
+    return val
+
+
 def pytest_addoption(parser):
     parser.addoption(
         "--stack-name",
@@ -66,12 +77,12 @@ def _configure_from_options(aws_profile):
 
 @pytest.fixture(scope="session")
 def urs_username():
-    return os.environ["URS_USERNAME"]
+    return get_env("URS_USERNAME")
 
 
 @pytest.fixture(scope="session")
 def urs_password():
-    return Secret(os.environ["URS_PASSWORD"])
+    return Secret(get_env("URS_PASSWORD"))
 
 
 class Secret():

--- a/tests_e2e/test_auth.py
+++ b/tests_e2e/test_auth.py
@@ -2,9 +2,11 @@ import requests
 from requests.auth import HTTPBasicAuth
 
 
-def test_auth_process(urls, api_host, urs_username, urs_password):
+def test_auth_process(urls, api_host, creds):
     url = urls.join(urls.METADATA_FILE)
     session = requests.session()
+    # Disable automatic detection of .netrc.
+    session.trust_env = False
 
     # Follow redirects to get the urthdata URL. We will get access denied because
     # we aren't passing our creds in yet.
@@ -12,6 +14,7 @@ def test_auth_process(urls, api_host, urs_username, urs_password):
     assert resp1.status_code == 401
 
     url_earthdata = resp1.url
+    urs_username, urs_password = creds.get(url_earthdata)
     resp2 = session.get(url_earthdata, auth=HTTPBasicAuth(urs_username, str(urs_password)))
 
     assert resp2.status_code == 200


### PR DESCRIPTION
The bucket map refactor actually had an issue that wasn't caught by the unit tests but was caught by the end to end tests. This adds equivalent unit tests and refactors some other stuff to make the unit tests play a little nicer.