### PR TITLE
Fix end to end tests deploy

### DIFF
--- a/.github/workflows/re-test-e2e.yml
+++ b/.github/workflows/re-test-e2e.yml
@@ -7,15 +7,6 @@ on:
       environment:
         required: true
         type: string
-      dependency-zip:
-        required: true
-        type: string
-      code-zip:
-        required: true
-        type: string
-      cloudformation-yaml:
-        required: true
-        type: string
 
     secrets:
       AWS_ACCESS_KEY_ID:
@@ -48,6 +39,9 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
       AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
+      DEPENDENCY_NAME: tea-dependencylayer-run.${{ github.run_id }}.zip
+      CODE_NAME: tea-code-run.${{ github.run_id }}.zip
+      YAML_NAME: tea-cloudformation-run.${{ github.run_id }}.yaml
 
     steps:
       - uses: actions/checkout@v2
@@ -61,9 +55,9 @@ jobs:
         env:
           S3_PATH_PREFIX: s3://${{ env.CODE_BUCKET }}/${{ env.CODE_PREFIX }}
         run: |
-          aws s3 cp ./dependency-layer/thin-egress-app-dependencies.zip ${S3_PATH_PREFIX}${{ inputs.dependency-zip }}
-          aws s3 cp ./code/thin-egress-app-code.zip ${S3_PATH_PREFIX}${{ inputs.code-zip }}
-          aws s3 cp ./cloudformation/thin-egress-app.yaml ${S3_PATH_PREFIX}${{ inputs.cloudformation-yaml }}
+          aws s3 cp ./dependency-layer/thin-egress-app-dependencies.zip ${S3_PATH_PREFIX}${DEPENDENCY_NAME}
+          aws s3 cp ./code/thin-egress-app-code.zip ${S3_PATH_PREFIX}${CODE_NAME}
+          aws s3 cp ./cloudformation/thin-egress-app.yaml ${S3_PATH_PREFIX}${YAML_NAME}
 
       - name: Update JWT secret
         if: env.JWT_KEY_SECRET_NAME == ''
@@ -161,9 +155,9 @@ jobs:
                   EnableApiGatewayLogToCloudWatch="False" \
                   JwtAlgo="RS256" \
                   JwtKeySecretName="$JWT_KEY_SECRET_NAME" \
-                  LambdaCodeDependencyArchive="${CODE_PREFIX}${{ inputs.dependency-zip }}" \
+                  LambdaCodeDependencyArchive="${CODE_PREFIX}${DEPENDENCY_NAME}" \
                   LambdaCodeS3Bucket="$CODE_BUCKET" \
-                  LambdaCodeS3Key="${CODE_PREFIX}${{ inputs.code-zip }}" \
+                  LambdaCodeS3Key="${CODE_PREFIX}${CODE_NAME}" \
                   LambdaMemory="128" \
                   Loglevel="DEBUG" \
                   Logtype="json" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,6 @@ jobs:
     uses: ./.github/workflows/re-test-e2e.yml
     with:
       environment: test
-      dependency-zip: ${{ needs.build.outputs.dependency-zip }}
-      code-zip: ${{ needs.build.outputs.code-zip }}
-      cloudformation-yaml: ${{ needs.build.outputs.cloudformation-yaml }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY:  ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -33,9 +33,6 @@ jobs:
     uses: ./.github/workflows/re-test-e2e.yml
     with:
       environment: test
-      dependency-zip: ${{ needs.build.outputs.dependency-zip }}
-      code-zip: ${{ needs.build.outputs.code-zip }}
-      cloudformation-yaml: ${{ needs.build.outputs.cloudformation-yaml }}
     # Reusable workflows + Environments behave very strangely
     # https://github.com/AllanOricil/workflow-template-bug/blob/fc8ae4264938adb560fa6928cb19c69d110d8bbd/.github/workflows/workflow-inplementation.yml#L46
     # Yea, seriously hope this gets fixed!!!!!

--- a/tests_e2e/conftest.py
+++ b/tests_e2e/conftest.py
@@ -115,7 +115,7 @@ class CredsHelper():
             res = urllib.parse.urlparse(url)
             entry = self.netrc_file.hosts.get(res.hostname)
             if entry:
-                (login, account, password) = entry
+                login, _, password = entry
                 return login, Secret(password)
 
         return get_env("URS_USERNAME"), Secret(get_env("URS_PASSWORD"))


### PR DESCRIPTION
The artifact names were based on branch name, so when the end to end tests would run against the devel branch, sometimes the lambda code would not be forced to update since the file name was the same. This should ensure that a new file is created for each run, and therefore the lambda code is always refreshed.