### PR TITLE
PR-3134 End to end test for gdal download

### DIFF
--- a/tests_e2e/test_gdal.py
+++ b/tests_e2e/test_gdal.py
@@ -1,5 +1,6 @@
 # Some common use cases that users might have for interacting with TEA data
 # through GDAL. In particular using the vsicurl driver.
+import hashlib
 from http.cookiejar import MozillaCookieJar
 
 import pytest
@@ -9,6 +10,8 @@ gdal = pytest.importorskip("osgeo.gdal")
 GRANULE = "S1A_IW_SLC__1SVV_20150604T161908_20150604T161939_006226_008216_5A4E"
 ZIP_FILE = f"{GRANULE}.zip"
 SAFE_FILE = f"{GRANULE}.SAFE"
+XML_FILE = "s1a-iw1-slc-vv-20150604t161908-20150604t161939-006226-008216-001.xml"
+XML_SIZE = 995_130
 
 
 @pytest.fixture(autouse=True)
@@ -19,7 +22,7 @@ def _config(tmp_path, auth_cookies):
     cookiejar = MozillaCookieJar(cookie_file_name)
     for cookie in auth_cookies:
         cookiejar.set_cookie(cookie)
-    cookiejar.save()
+    cookiejar.save(ignore_discard=True)
 
     gdal.UseExceptions()
     gdal.SetConfigOption("GDAL_HTTP_COOKIEFILE", cookie_file_name)
@@ -33,3 +36,19 @@ def test_list_zip_contents(urls):
     res = gdal.ReadDir(f"/vsizip/vsicurl/{url}")
 
     assert res == [SAFE_FILE]
+
+
+def test_download_file_contents(urls):
+    url = urls.join("SA", "SLC", ZIP_FILE, SAFE_FILE, "annotation", XML_FILE)
+    path = f"/vsizip/vsicurl/{url}"
+
+    stats = gdal.VSIStatL(path)
+    assert stats is not None
+    assert stats.size == XML_SIZE
+
+    vfid = gdal.VSIFOpenL(path, "rb")
+    data = gdal.VSIFReadL(1, stats.size, vfid)
+    gdal.VSIFCloseL(vfid)
+
+    assert len(data) == XML_SIZE
+    assert hashlib.md5(data).hexdigest() == "6f16f3342cec02a9f8ecc29fd4f51a86"


### PR DESCRIPTION
Adds a test that downloads one of the files contained in the zip archive using GDAL.

It seems that the HEAD request to get the file size is required, as disabling it causes GDAL to error out on the redirect to s3.