### PR TITLE
Increase lambda timeout for end to end tests

### DIFF
--- a/.github/workflows/re-test-e2e.yml
+++ b/.github/workflows/re-test-e2e.yml
@@ -159,6 +159,7 @@ jobs:
                   LambdaCodeS3Bucket="$CODE_BUCKET" \
                   LambdaCodeS3Key="${CODE_PREFIX}${CODE_NAME}" \
                   LambdaMemory="128" \
+                  LambdaTimeout="10" \
                   Loglevel="DEBUG" \
                   Logtype="json" \
                   Maturity="TEST"\

--- a/build/Jenkinsfile
+++ b/build/Jenkinsfile
@@ -67,7 +67,7 @@ pipeline {
     JWTKEYSECRETNAME="${JWTKEYSECRETNAME}"
     JWTALGO="RS256"
     ZIPFILENAME="${DEPENDENCY_LAYER_FILENAME}"
-    LAMBDA_TIMEOUT=6
+    LAMBDA_TIMEOUT=10
     LAMBDA_MEMORY=128
     AWS_BIN="/usr/local/bin/aws"
     CODE_BUCKET_SUFFIX="""${sh(script:'if [ "${AWS_DEFAULT_REGION}" = "us-west-2" ]; then printf %s ".usw2"; else printf %s ""; fi', returnStdout: true)}"""


### PR DESCRIPTION
It seems that one test in particular `tests_e2e/test_jwt_blacklist.py::test_validate_valid_jwt` sometimes fails due to the lambda timeout since it always triggers a cold start. I'm not sure there's much we can do about that besides increase the timeout.