### PR TITLE
PR-3224 Bump rain-api-core version

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -2,5 +2,5 @@ cachetools
 cfnresponse
 chalice
 flatdict
-git+https://github.com/asfadmin/rain-api-core.git@a6ec7f50899a83d663752266d63340a54245bec9
+git+https://github.com/asfadmin/rain-api-core.git@5c8ff9c3102b5835c4bf0bb0f653e59ea4c191ea
 netaddr


### PR DESCRIPTION
Fixes the log censor for flat logging mode. https://github.com/asfadmin/rain-api-core/pull/273