### PR TITLE
PR-3244 Add s3 credentials endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,7 @@ endif
 	python3 scripts/sed.py -i $(DIR)/thin-egress-app.yaml "<CODE_ARCHIVE_PATH_FILENAME>" "${CF_DEFAULT_CODE_ARCHIVE_KEY}"
 	python3 scripts/sed.py -i $(DIR)/thin-egress-app.yaml "<BUILD_ID>" "${CF_BUILD_VERSION}"
 	python3 scripts/sed.py -i $(DIR)/thin-egress-app.yaml "^Description:.*" 'Description: "${CF_DESCRIPTION}"'
+	python3 scripts/sed.py -i $(DIR)/thin-egress-app.yaml "EgressAPIdeployment" "EgressAPIdeployment`python3 -c 'import random; print(random.randint(0, 2**20))'`"
 
 .SECONDARY: $(DIST_TERRAFORM)
 $(DIST_TERRAFORM): $(DIR)/%: %

--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ $(EMPTY)/.deploy-stack: $(DIR)/thin-egress-app.yaml $(EMPTY)/.deploy-dependencie
 					AuthBaseUrl=$(URS_URL) \
 					ConfigBucket=$(CONFIG_BUCKET) \
 					LambdaCodeS3Bucket=$(CODE_BUCKET) \
-					PermissionsBoundaryName= \
+					PermissionsBoundaryName=$(PERMISSION_BOUNDARY_NAME) \
 					BucketnamePrefix=$(BUCKETNAME_PREFIX) \
 					DownloadRoleArn="" \
 					DownloadRoleInRegionArn="" \
@@ -210,9 +210,9 @@ $(EMPTY)/.deploy-stack: $(DIR)/thin-egress-app.yaml $(EMPTY)/.deploy-dependencie
 					Loglevel=DEBUG \
 					Logtype=$(LOG_TYPE) \
 					Maturity=DEV \
-					PrivateVPC= \
-					VPCSecurityGroupIDs= \
-					VPCSubnetIDs= \
+					PrivateVPC=$(PRIVATE_VPC) \
+					VPCSecurityGroupIDs=$(VPC_SECURITY_GROUP_IDS) \
+					VPCSubnetIDs=$(VPC_SUBNET_IDS) \
 					EnableApiGatewayLogToCloudWatch="False" \
 					DomainName=$(DOMAIN_NAME-"") \
 					DomainCertArn=$(DOMAIN_CERT_ARN-"") \

--- a/Makefile
+++ b/Makefile
@@ -214,6 +214,7 @@ $(EMPTY)/.deploy-stack: $(DIR)/thin-egress-app.yaml $(EMPTY)/.deploy-dependencie
 					VPCSecurityGroupIDs=$(VPC_SECURITY_GROUP_IDS) \
 					VPCSubnetIDs=$(VPC_SUBNET_IDS) \
 					EnableApiGatewayLogToCloudWatch="False" \
+					EnableS3CredentialsEndpoint="True" \
 					DomainName=$(DOMAIN_NAME-"") \
 					DomainCertArn=$(DOMAIN_CERT_ARN-"") \
 					CookieDomain=$(COOKIE_DOMAIN-"") \

--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -42,6 +42,16 @@ URS_URL := https://uat.urs.earthdata.nasa.gov
 # Logging style, either `flat` for human readable or `json` for machine readable
 LOG_TYPE := flat
 
+########################
+# For NGAP Deployments #
+########################
+# In an NGAP environment you must uncomment the following line or the deployment will fail
+# PERMISSION_BOUNDARY_NAME := NGAPShRoleBoundary
+
+PRIVATE_VPC :=
+VPC_SECURITY_GROUP_IDS :=
+VPC_SUBNET_IDS :=
+
 ####################################
 # CloudFormation Template Defaults #
 ####################################

--- a/cloudformation/thin-egress-app.yaml
+++ b/cloudformation/thin-egress-app.yaml
@@ -696,6 +696,15 @@ Resources:
       PathPart: '{proxy+}'
       RestApiId: !Ref EgressApiGateway
 
+  EgressApiResourceS3Credentials:
+    Type: AWS::ApiGateway::Resource
+    DependsOn:
+      - EgressApiGateway
+    Properties:
+      ParentId: !GetAtt EgressApiGateway.RootResourceId
+      PathPart: 's3credentials'
+      RestApiId: !Ref EgressApiGateway
+
   EgressApiResourceProfile:
     Type: AWS::ApiGateway::Resource
     DependsOn:
@@ -881,6 +890,27 @@ Resources:
         'method.request.header.Cookie': true
         'method.request.header.X-urs-access-token': true
       ResourceId: !Ref EgressApiResourceDynamicUrl
+      RestApiId: !Ref EgressApiGateway
+
+  EgressAPIMethodS3Credentials:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      ApiKeyRequired: false
+      AuthorizationType: 'NONE'
+      HttpMethod: 'GET'
+      Integration:
+        IntegrationHttpMethod: 'POST'
+        IntegrationResponses:
+          - StatusCode: 200
+          - StatusCode: 401
+        Type: 'AWS_PROXY'
+        Uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${EgressLambda.Arn}/invocations"
+      OperationName: 's3credentials view'
+      RequestParameters:
+        'method.request.header.Cookie': true
+        'method.request.header.X-urs-access-token': true
+        'method.request.header.X-urs-app-name': false
+      ResourceId: !Ref EgressApiResourceS3Credentials
       RestApiId: !Ref EgressApiGateway
 
   EgressAPIMethodProfile:

--- a/cloudformation/thin-egress-app.yaml
+++ b/cloudformation/thin-egress-app.yaml
@@ -16,6 +16,7 @@ Metadata:
           - HtmlTemplateDir
           - StageName
           - EnableApiGatewayLogToCloudWatch
+          - EnableS3CredentialsEndpoint
       -
         Label:
           default: Domain Settings
@@ -260,6 +261,14 @@ Parameters:
       - "True"
     Description: 'Optional flag to enable (True) Api Gateway logging to CloudWatch. If "True", you must add an ARN for a role with write access to CloudWatch Logs in your account here: https://console.aws.amazon.com/apigateway/home?region=[REGION]#/settings'
 
+  EnableS3CredentialsEndpoint:
+    Type: String
+    Default: "False"
+    AllowedValues:
+      - "False"
+      - "True"
+    Description: 'Optional flag to enable (True) the /s3credentials endpoint for handing out S3 direct access credentials.'
+
   # Open Telemetry settings:::
 
   OtLambdaExecWrapper:
@@ -300,6 +309,7 @@ Parameters:
 Conditions:
   DomainNameIsSet: !Not [ !Equals [ !Ref DomainName, "" ] ]
   ApiGatewayLogToCloudWatchIsSet: !Equals [ !Ref EnableApiGatewayLogToCloudWatch, "True" ]
+  S3CredentialsEndpointIsSet: !Equals [ !Ref EnableS3CredentialsEndpoint, "True" ]
   CreateDownloadRole: !Equals [ !Ref DownloadRoleArn, "" ]
   UsePermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryName, "" ] ]
   UsePrivateVPC: !Not [ !Equals [ !Ref PrivateVPC, "" ] ]
@@ -698,6 +708,7 @@ Resources:
 
   EgressApiResourceS3Credentials:
     Type: AWS::ApiGateway::Resource
+    Condition: S3CredentialsEndpointIsSet
     DependsOn:
       - EgressApiGateway
     Properties:
@@ -894,6 +905,7 @@ Resources:
 
   EgressAPIMethodS3Credentials:
     Type: AWS::ApiGateway::Method
+    Condition: S3CredentialsEndpointIsSet
     Properties:
       ApiKeyRequired: false
       AuthorizationType: 'NONE'

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,10 +102,10 @@ MAP:
    data-path: data-bucket
 
 PUBLIC_BUCKETS:
-   data-bucket/browse: "Browse image"
+   data-bucket/browse/: "Browse image"
 
 PRIVATE_BUCKETS:
-   data-bucket/pre-commission-data:
+   data-bucket/pre-commission-data/:
      - internal_users
      - external_team
 ```
@@ -113,6 +113,36 @@ PRIVATE_BUCKETS:
 In the above example, while access to data in `data-bucket` requires simple auth,
 accessing an object with the prefix `browse/` will require NO auth, and
 `pre-commission-data/` will require EDL App group access as specified.
+
+#### S3 Direct Access
+*NOTE: Support for S3 direct access is currently experimental*
+
+TEA can be deployed with an `/s3credentials` endpoint (See
+[Enabling S3 direct access](deploying.md#enabling-s3-direct-access)) for
+facilitating S3 direct access. Credentials handed out over this endpoint will
+have both `s3:ListBucket` and `s3:GetObject` permissions for in-region requests
+to prefixes configured in the bucket map.
+
+For example:
+
+```yaml
+MAP:
+   data-path: data-bucket
+
+PUBLIC_BUCKETS:
+   data-bucket/browse/: "Browse image"
+
+PRIVATE_BUCKETS:
+   data-bucket/pre-commission-data/:
+     - internal_users
+     - external_team
+```
+
+Using this bucket map, the `/s3credentials` endpoint would return credentials
+allowing in-region access to any objects in `data-bucket` EXCEPT objects that
+have the `pre-commission-data/` prefix to any logged in user. Any user in the
+`internal_users` or `external_team` groups would be able to use their
+credentials to access all data in the bucket.
 
 ## Custom Templating
 
@@ -155,11 +185,11 @@ Child template that displays profile info. Only used for debugging in dev.
 
 ## Shared Token Support
 
-TEA can accept a shared [EDL Token](https://urs.earthdata.nasa.gov/documentation/for_users/user_token) 
-as an Authorization (Bearer Token) method. To enable this behavior, EDL Apps 
-(Service + TEA) must belong to a shared EDL App Group. Processing a 
-shared token is temporally expensive. After the initial request, subsequent 
-Service->TEA data requests should reuse cookies. EULA enforcement is 
+TEA can accept a shared [EDL Token](https://urs.earthdata.nasa.gov/documentation/for_users/user_token)
+as an Authorization (Bearer Token) method. To enable this behavior, EDL Apps
+(Service + TEA) must belong to a shared EDL App Group. Processing a
+shared token is temporally expensive. After the initial request, subsequent
+Service->TEA data requests should reuse cookies. EULA enforcement is
 preserved with shared tokens.
 
 ![TEA](images/harmony-chain.png)

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -126,6 +126,7 @@ aws $AWSENV secretsmanager create-secret --name jwt_secret_for_tea \
    * `HtmlTemplateDir` - (OPTIONAL) Subdirectory of `ConfigBucket` where templates can be found
    * `StageName` - API Gateway Stage value
    * `EnableApiGatewayLogToCloudWatch` - Whether or not API Gateway logs should be dumped
+   * `EnableS3CredentialsEndpoint` - Whether or not to deploy the /s3credentials endpoint for s3 direct access.
 * **Domain Settings**:
    * `DomainName` - (OPTIONAL) domain name as a user will access it (ie CloudFront, CNAME, etc)
    * `CookieDomain` - (OPTIONAL) domain name value for minting cookies
@@ -236,6 +237,23 @@ a write up for this, I'd love to include it.
 Please see the
 [Cumulus documentation](https://nasa.github.io/cumulus/docs/deployment/thin_egress_app)
 for current TEA deployment and configuration procedures.
+
+### Enabling S3 direct access
+*NOTE: Support for S3 direct access is currently experimental*
+
+TEA supports handing out s3 direct access credentials over the optional
+`/s3credentials` endpoint. This endpoint can be deployed by setting the
+parameter `EnableS3CredentialsEndpoint="True"` in CloudFormation or by setting
+the parameter `s3credentials_endpoint=true` in Terraform.
+
+*NOTE: Once you've deployed the CloudFormation template, you will need to
+manually update the API Gateway deployment if you ever want to change the value
+of `EnableS3CredentialsEndpoint`. This can also be forced in CloudFormation by
+adding a random number to the name of the ApiGateway Deployment resource before
+redeploying the stack.*
+
+See [S3 Direct Access](configuration.md#s3-direct-access) for a details on how
+the endpoint configuration works.
 
 ## Post deployment procedures
 

--- a/docs/s3access.md
+++ b/docs/s3access.md
@@ -1,0 +1,83 @@
+## S3 Direct Access
+*NOTE: Support for S3 direct access is currently experimental*
+
+You can retrieve temporary S3 credentials at the `/s3credentials` endpoint when
+authenticated via earthdata login. These credentials will be valid for 1 hour
+and can be used make in-region `s3:ListBucket` and `s3:GetObject` requests.
+
+### Request
+Credentials are retrieved through a `GET` request to the `/s3credentials`
+endpoint. An optional header `app-name` can be provided to include in the
+generated role session name which will show up in EMS logs.
+
+**Params:**
+None.
+
+**Headers:**
+  - `app-name`: A string to include in the generated role session name for
+  metric reporting purposes. It is recommended to include this header when
+  making requests on users behalf from another cloud service. The generated
+  role session name is `username@app-name`.
+
+**Example:**
+```python
+import requests
+
+requests.get(
+    "https://your-tea-host/s3credentials",
+    headers={"app-name": "my-application"},
+    cookies={"asf-urs": "<your jwt token>"}
+)
+```
+
+### Response
+The response is your temporary credentials as returned by Amazon STS.
+[See the AWS Credentials reference](https://docs.aws.amazon.com/STS/latest/APIReference/API_Credentials.html")
+
+**Example:**
+```json
+{
+  "AccessKeyId": "AKIAIOSFODNN7EXAMPLE",
+  "SecretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+  "SessionToken": "LONGSTRINGOFCHARACTERS.../HJLgV91QJFCMlmY8slIEOjrOChLQYmzAqrb5U1ekoQAK6f86HKJFTT2dONzPgmJN9ZvW5DBwt6XUxC9HAQ0LDPEYEwbjGVKkzSNQh/",
+  "Expiration": "2021-01-27 00:50:09+00:00"
+}
+```
+
+### Using Temporary Credentials
+To use the credentials you must configure your AWS client with the returned
+access key, secret and token. Note that the credentials will only work in-
+region, so you will get 403 errors if you try to use them with the AWS cli.
+
+**Example:**
+```python
+import boto3
+import requests
+
+def get_client():
+  resp = requests.get(
+      "https://your-tea-host/s3credentials",
+      headers={"app-name": "my-application"},
+      cookies={"asf-urs": "<your jwt token>"}
+  )
+  resp.raise_for_status()
+  creds = resp.json()
+
+  return boto3.client(
+      "s3",
+      aws_access_key_id=creds["AccessKeyId"],
+      aws_secret_access_key=creds["SecretAccessKey"],
+      aws_session_token=creds["SessionToken"]
+  )
+
+```
+
+### Limits
+
+The credentials dispensed from the `/s3credentials` endpoint are valid for
+**1 hour**. Your code must handle expired tokens and request new ones as needed
+for sessions that exceed this 1 hour limit. This is an AWS Limit is due to
+[role chaining](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_terms-and-concepts.html)
+
+These credentials will have `s3:GetObject` and `s3:ListBucket` permissions on
+the configured resources.

--- a/lambda/app.py
+++ b/lambda/app.py
@@ -808,14 +808,14 @@ def dynamic_url():
     timer = Timer()
     timer.mark("restore_bucket_vars()")
 
-    log.debug('attempting to GET a thing')
+    param = app.current_request.uri_params.get("proxy")
+    log.debug('attempting to GET: %s', param)
     restore_bucket_vars()
     log.debug(f'b_map: {b_map.bucket_map}')
     timer.mark()
 
     log.info(app.current_request.headers)
 
-    param = app.current_request.uri_params.get("proxy")
     entry = None
     if param is not None:
         entry = b_map.get(param)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,5 +18,6 @@ nav:
   - Vision: vision.md
   - Deploying: deploying.md
   - Configuration: configuration.md
+  - S3 Access: s3access.md
   - Technical: technical.md
   - Trouble Shooting: troubleshooting.md

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -8,37 +8,41 @@ attrs==21.4.0
     # via
     #   -c requirements/requirements.txt
     #   pytest
-boto3==1.23.7
+boto3==1.24.94
     # via -r requirements/requirements-dev.in
-botocore==1.26.7
+botocore==1.27.94
     # via
     #   -c requirements/requirements.txt
     #   boto3
     #   s3transfer
+build==0.8.0
+    # via pip-tools
 click==8.1.3
     # via
     #   -c requirements/requirements.txt
     #   pip-tools
-coverage[toml]==6.4
+coverage[toml]==6.5.0
     # via pytest-cov
 deprecated==1.2.13
     # via opentelemetry-api
 iniconfig==1.1.1
     # via pytest
-jmespath==1.0.0
+jmespath==1.0.1
     # via
     #   -c requirements/requirements.txt
     #   boto3
     #   botocore
-opentelemetry-api==1.11.1
+opentelemetry-api==1.13.0
     # via opentelemetry-instrumentation
-opentelemetry-instrumentation==0.31b0
+opentelemetry-instrumentation==0.34b0
     # via -r requirements/requirements-dev.in
 packaging==21.3
-    # via pytest
-pep517==0.12.0
-    # via pip-tools
-pip-tools==6.6.2
+    # via
+    #   build
+    #   pytest
+pep517==0.13.0
+    # via build
+pip-tools==6.9.0
     # via -r requirements/requirements-dev.in
 pluggy==1.0.0
     # via pytest
@@ -46,11 +50,11 @@ py==1.11.0
     # via pytest
 pyparsing==3.0.9
     # via packaging
-pytest==7.1.2
+pytest==7.1.3
     # via
     #   -r requirements/requirements-dev.in
     #   pytest-cov
-pytest-cov==3.0.0
+pytest-cov==4.0.0
     # via -r requirements/requirements-dev.in
 python-dateutil==2.8.2
     # via
@@ -60,7 +64,7 @@ pyyaml==6.0
     # via
     #   -c requirements/requirements.txt
     #   -r requirements/requirements-dev.in
-s3transfer==0.5.2
+s3transfer==0.6.0
     # via boto3
 six==1.16.0
     # via
@@ -68,10 +72,11 @@ six==1.16.0
     #   python-dateutil
 tomli==2.0.1
     # via
+    #   build
     #   coverage
     #   pep517
     #   pytest
-urllib3==1.26.9
+urllib3==1.26.12
     # via
     #   -c requirements/requirements.txt
     #   botocore

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -4,23 +4,23 @@
 #
 #    pip-compile requirements/requirements-test.in
 #
-attrs==21.4.0
+attrs==22.1.0
     # via pytest
-boto3==1.23.0
+boto3==1.24.94
     # via -r requirements/requirements-test.in
-botocore==1.26.0
+botocore==1.27.94
     # via
     #   boto3
     #   s3transfer
-certifi==2021.10.8
+certifi==2022.9.24
     # via requests
-charset-normalizer==2.0.12
+charset-normalizer==2.1.1
     # via requests
-idna==3.3
+idna==3.4
     # via requests
 iniconfig==1.1.1
     # via pytest
-jmespath==1.0.0
+jmespath==1.0.1
     # via
     #   boto3
     #   botocore
@@ -32,21 +32,21 @@ py==1.11.0
     # via pytest
 pyparsing==3.0.9
     # via packaging
-pytest==7.1.2
+pytest==7.1.3
     # via -r requirements/requirements-test.in
 python-dateutil==2.8.2
     # via botocore
 pyyaml==6.0
     # via -r requirements/requirements-test.in
-requests==2.27.1
+requests==2.28.1
     # via -r requirements/requirements-test.in
-s3transfer==0.5.2
+s3transfer==0.6.0
     # via boto3
 six==1.16.0
     # via python-dateutil
 tomli==2.0.1
     # via pytest
-urllib3==1.26.9
+urllib3==1.26.12
     # via
     #   botocore
     #   requests

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -2,5 +2,5 @@ cachetools
 cfnresponse
 chalice
 flatdict
-git+https://github.com/asfadmin/rain-api-core.git@5c8ff9c3102b5835c4bf0bb0f653e59ea4c191ea
+git+https://github.com/asfadmin/rain-api-core.git@6acd2cb943cb552c525bc5320297f62b812a33ba
 netaddr

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -8,43 +8,41 @@ attrs==21.4.0
     # via chalice
 blessed==1.19.1
     # via inquirer
-botocore==1.26.7
+botocore==1.27.94
     # via chalice
 cachetools==5.0.0
     # via
     #   -r requirements/requirements.in
     #   rain-api-core
-cffi==1.15.0
+cffi==1.15.1
     # via cryptography
 cfnresponse==1.1.2
     # via -r requirements/requirements.in
-chalice==1.27.0
+chalice==1.27.3
     # via -r requirements/requirements.in
 click==8.1.3
     # via chalice
-cryptography==37.0.2
+cryptography==38.0.1
     # via pyjwt
 flatdict==4.0.1
     # via -r requirements/requirements.in
-inquirer==2.9.2
+inquirer==2.10.0
     # via chalice
 jinja2==3.1.2
     # via rain-api-core
-jmespath==1.0.0
+jmespath==1.0.1
     # via
     #   botocore
     #   chalice
 markupsafe==2.1.1
     # via jinja2
-mypy-extensions==0.4.3
-    # via chalice
 netaddr==0.8.0
     # via
     #   -r requirements/requirements.in
     #   rain-api-core
 pycparser==2.21
     # via cffi
-pyjwt[crypto]==2.4.0
+pyjwt[crypto]==2.5.0
     # via rain-api-core
 python-dateutil==2.8.2
     # via botocore
@@ -56,14 +54,18 @@ pyyaml==6.0
     #   rain-api-core
 rain-api-core @ git+https://github.com/asfadmin/rain-api-core.git@6acd2cb943cb552c525bc5320297f62b812a33ba
     # via -r requirements/requirements.in
-readchar==3.0.5
+readchar==4.0.3
     # via inquirer
 six==1.16.0
     # via
     #   blessed
     #   chalice
     #   python-dateutil
-urllib3==1.26.9
+types-cryptography==3.3.23.1
+    # via pyjwt
+typing-extensions==4.4.0
+    # via chalice
+urllib3==1.26.12
     # via
     #   botocore
     #   cfnresponse

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -54,7 +54,7 @@ pyyaml==6.0
     # via
     #   chalice
     #   rain-api-core
-rain-api-core @ git+https://github.com/asfadmin/rain-api-core.git@5c8ff9c3102b5835c4bf0bb0f653e59ea4c191ea
+rain-api-core @ git+https://github.com/asfadmin/rain-api-core.git@6acd2cb943cb552c525bc5320297f62b812a33ba
     # via -r requirements/requirements.in
 readchar==3.0.5
     # via inquirer

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -63,6 +63,7 @@ resource "aws_cloudformation_stack" "thin_egress_app" {
     DownloadRoleArn                 = var.download_role_arn
     DownloadRoleInRegionArn         = var.download_role_in_region_arn
     EnableApiGatewayLogToCloudWatch = var.log_api_gateway_to_cloudwatch ? "True" : "False"
+    EnableS3CredentialsEndpoint     = var.s3credentials_endpoint ? "True" : "False"
     HtmlTemplateDir                 = var.html_template_dir
     JwtAlgo                         = var.jwt_algo
     JwtKeySecretName                = var.jwt_secret_name

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -104,6 +104,12 @@ variable "log_api_gateway_to_cloudwatch" {
   description = "Switch that will enable logging of api gateway request/response to cloudwatch."
 }
 
+variable "s3credentials_endpoint" {
+  type        = bool
+  default     = false
+  description = "Switch that will enable deployment of the /s3credentials endpoint for s3 direct access."
+}
+
 variable "suppress_head_check" {
   type        = bool
   default     = false

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1296,6 +1296,60 @@ def test_dynamic_url_bearer_auth(
     assert response.headers == {}
 
 
+@mock.patch(f"{MODULE}.get_s3_credentials", autospec=True)
+@mock.patch(f"{MODULE}.get_yaml_file", autospec=True)
+@mock.patch(f"{MODULE}.JwtManager.get_profile_from_headers", autospec=True)
+@mock.patch(f"{MODULE}.b_map", None)
+def test_s3credentials(
+    mock_get_profile,
+    mock_get_yaml_file,
+    mock_get_s3_credentials,
+    resources,
+    user_profile,
+    client
+):
+    mock_get_s3_credentials.return_value = {
+        "AccessKeyId": "access_key",
+        "SecretAccessKey": "secret_access_key",
+        "SessionToken": "session_token",
+        "Expiration": "expiration"
+    }
+    with resources.open("bucket_map_example.yaml") as f:
+        mock_get_yaml_file.return_value = yaml.full_load(f)
+    mock_get_profile.return_value = user_profile
+
+    response = client.http.get("/s3credentials")
+
+    assert response.json_body == {
+        "AccessKeyId": "access_key",
+        "SecretAccessKey": "secret_access_key",
+        "SessionToken": "session_token",
+        "Expiration": "expiration"
+    }
+    assert response.status_code == 200
+
+
+@mock.patch(f"{MODULE}.get_yaml_file", autospec=True)
+@mock.patch(f"{MODULE}.JwtManager.get_profile_from_headers", autospec=True)
+@mock.patch(f"{MODULE}.b_map", None)
+def test_s3credentials_unauthenticated(
+    mock_get_profile,
+    mock_get_yaml_file,
+    mock_make_html_response,
+    resources,
+    client
+):
+    with resources.open("bucket_map_example.yaml") as f:
+        mock_get_yaml_file.return_value = yaml.full_load(f)
+    mock_get_profile.return_value = None
+
+    response = client.http.get("/s3credentials")
+
+    mock_make_html_response.assert_called_once()
+    assert response.body == b"Mock response"
+    assert response.status_code == 401
+
+
 def test_profile(client):
     response = client.http.get("/profile")
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -66,6 +66,13 @@ def mock_get_urs_creds():
 
 
 @pytest.fixture
+def mock_get_urs_url():
+    with mock.patch(f"{MODULE}.get_urs_url", autospec=True) as m:
+        m.return_value = "https://urs.example.domain?redirect=oururl"
+        yield m
+
+
+@pytest.fixture
 def mock_make_html_response():
     with mock.patch(f"{MODULE}.TEMPLATE_MANAGER", autospec=True) as mgr:
         original_make_html_response = app.make_html_response
@@ -87,6 +94,166 @@ def test_update_blacklist(mock_request, monkeypatch):
     monkeypatch.setenv("BLACKLIST_ENDPOINT", endpoint)
     mock_request.urlopen(endpoint).read.return_value = b'{"blacklist": {"foo": "bar"}}'
     assert app.get_black_list() == {"foo": "bar"}
+
+
+def test_request_authorizer_no_headers(current_request, mock_get_urs_url):
+    current_request.headers = {}
+    current_request.context = {"path": "/foo"}
+    authorizer = app.RequestAuthorizer()
+
+    assert authorizer.get_profile() is None
+    response = authorizer.get_error_response()
+    assert response is not None
+    assert response.body == ""
+    assert response.status_code == 302
+    assert authorizer.get_success_response_headers() == {}
+
+
+@mock.patch(f"{MODULE}.get_user_from_token", autospec=True)
+@mock.patch(f"{MODULE}.get_new_token_and_profile", autospec=True)
+def test_request_authorizer_bearer_header(mock_get_new_token_and_profile, mock_get_user_from_token, current_request):
+    current_request.headers = {
+        "Authorization": "Bearer token",
+        "x-origin-request-id": "origin_request_id"
+    }
+    mock_user_profile = mock.Mock()
+    mock_get_new_token_and_profile.return_value = mock_user_profile
+    mock_get_user_from_token.return_value = "user_name"
+
+    authorizer = app.RequestAuthorizer()
+
+    assert authorizer.get_profile() == mock_user_profile
+    mock_get_new_token_and_profile.assert_called_once_with(
+        "user_name",
+        True,
+        aux_headers={
+            "x-request-id": "request_1234",
+            "x-origin-request-id": "origin_request_id"
+        }
+    )
+
+
+@mock.patch(f"{MODULE}.do_auth_and_return", autospec=True)
+def test_request_authorizer_basic_header(mock_do_auth_and_return, current_request):
+    current_request.headers = {
+        "Authorization": "Basic token",
+        "x-origin-request-id": "origin_request_id"
+    }
+    mock_response = mock.Mock()
+    mock_do_auth_and_return.return_value = mock_response
+
+    authorizer = app.RequestAuthorizer()
+
+    assert authorizer.get_profile() is None
+    assert authorizer.get_error_response() == mock_response
+
+
+@mock.patch(f"{MODULE}.get_user_from_token", autospec=True)
+def test_request_authorizer_bearer_header_eula_error(mock_get_user_from_token, current_request):
+    current_request.headers = {"Authorization": "Bearer token"}
+    mock_get_user_from_token.side_effect = app.EulaException({})
+
+    authorizer = app.RequestAuthorizer()
+
+    assert authorizer.get_profile() is None
+
+    response = authorizer.get_error_response()
+    assert response.status_code == 403
+    assert response.headers == {}
+
+
+@mock.patch(f"{MODULE}.get_user_from_token", autospec=True)
+def test_request_authorizer_bearer_header_eula_error_browser(
+    mock_get_user_from_token,
+    mock_make_html_response,
+    current_request
+):
+    current_request.headers = {
+        "Authorization": "Bearer token",
+        "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
+    }
+    mock_get_user_from_token.side_effect = app.EulaException({
+        "status_code": 403,
+        "error_description": "EULA Acceptance Failure",
+        "resolution_url": "http://resolution_url"
+    })
+
+    authorizer = app.RequestAuthorizer()
+
+    assert authorizer.get_profile() is None
+
+    response = authorizer.get_error_response()
+    mock_make_html_response.assert_called_once_with(
+        {
+            "title": "EULA Acceptance Failure",
+            "status_code": 403,
+            "contentstring": (
+                'Could not fetch data because "EULA Acceptance Failure". Please accept EULA here: '
+                '<a href="http://resolution_url">http://resolution_url</a> and try again.'
+            ),
+            "requestid": "request_1234",
+        },
+        {},
+        403,
+        "error.html"
+    )
+    assert response.status_code == 403
+    assert response.headers == {"Content-Type": "text/html"}
+
+
+@mock.patch(f"{MODULE}.get_user_from_token", autospec=True)
+@mock.patch(f"{MODULE}.get_new_token_and_profile", autospec=True)
+@mock.patch(f"{MODULE}.do_auth_and_return", autospec=True)
+def test_request_authorizer_bearer_header_no_profile(
+    mock_do_auth_and_return,
+    mock_get_new_token_and_profile,
+    mock_get_user_from_token,
+    current_request
+):
+    current_request.headers = {
+        "Authorization": "Bearer token",
+        "x-origin-request-id": "origin_request_id"
+    }
+    mock_response = mock.Mock()
+    mock_do_auth_and_return.return_value = mock_response
+    mock_get_new_token_and_profile.return_value = False
+    mock_get_user_from_token.return_value = "user_name"
+
+    authorizer = app.RequestAuthorizer()
+
+    assert authorizer.get_profile() is None
+    assert authorizer.get_error_response() == mock_response
+    mock_get_new_token_and_profile.assert_called_once_with(
+        "user_name",
+        True,
+        aux_headers={
+            "x-request-id": "request_1234",
+            "x-origin-request-id": "origin_request_id"
+        }
+    )
+    mock_do_auth_and_return.assert_called_once_with(current_request.context)
+
+
+@mock.patch(f"{MODULE}.get_user_from_token", autospec=True)
+@mock.patch(f"{MODULE}.do_auth_and_return", autospec=True)
+def test_request_authorizer_bearer_header_no_user_id(
+    mock_do_auth_and_return,
+    mock_get_user_from_token,
+    current_request
+):
+    current_request.headers = {
+        "Authorization": "Bearer token",
+        "x-origin-request-id": "origin_request_id"
+    }
+    mock_response = mock.Mock()
+    mock_do_auth_and_return.return_value = mock_response
+    mock_get_user_from_token.return_value = None
+
+    authorizer = app.RequestAuthorizer()
+
+    assert authorizer.get_profile() is None
+    assert authorizer.get_error_response() == mock_response
+    mock_do_auth_and_return.assert_called_once_with(current_request.context)
 
 
 def test_get_request_id(lambda_context):
@@ -876,112 +1043,6 @@ def test_dynamic_url_head_missing_proxy(mock_get_yaml_file, current_request):
     assert response.status_code == 400
 
 
-@mock.patch(f"{MODULE}.get_user_from_token", autospec=True)
-@mock.patch(f"{MODULE}.get_new_token_and_profile", autospec=True)
-def test_handle_auth_bearer_header(mock_get_new_token_and_profile, mock_get_user_from_token, current_request):
-    current_request.headers = {"x-origin-request-id": "origin_request_id"}
-    mock_user_profile = mock.Mock()
-    mock_get_new_token_and_profile.return_value = mock_user_profile
-    mock_get_user_from_token.return_value = "user_name"
-
-    assert app.handle_auth_bearer_header(mock.Mock()) == ("user_profile", mock_user_profile)
-    mock_get_new_token_and_profile.assert_called_once_with(
-        "user_name",
-        True,
-        aux_headers={
-            "x-request-id": "request_1234",
-            "x-origin-request-id": "origin_request_id"
-        }
-    )
-
-
-@mock.patch(f"{MODULE}.get_user_from_token", autospec=True)
-def test_handle_auth_bearer_header_eula_error(mock_get_user_from_token, current_request):
-    current_request.headers = {"x-origin-request-id": "origin_request_id"}
-    mock_get_user_from_token.side_effect = app.EulaException({})
-
-    action, response = app.handle_auth_bearer_header(mock.Mock())
-    assert action == "return"
-    assert response.status_code == 403
-    assert response.headers == {}
-
-
-@mock.patch(f"{MODULE}.get_user_from_token", autospec=True)
-def test_handle_auth_bearer_header_eula_error_browser(
-    mock_get_user_from_token,
-    mock_make_html_response,
-    current_request
-):
-    current_request.headers = {"user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"}
-    mock_get_user_from_token.side_effect = app.EulaException({
-        "status_code": 403,
-        "error_description": "EULA Acceptance Failure",
-        "resolution_url": "http://resolution_url"
-    })
-
-    action, response = app.handle_auth_bearer_header(mock.Mock())
-    mock_make_html_response.assert_called_once_with(
-        {
-            "title": "EULA Acceptance Failure",
-            "status_code": 403,
-            "contentstring": (
-                'Could not fetch data because "EULA Acceptance Failure". Please accept EULA here: '
-                '<a href="http://resolution_url">http://resolution_url</a> and try again.'
-            ),
-            "requestid": "request_1234",
-        },
-        {},
-        403,
-        "error.html"
-    )
-    assert action == "return"
-    assert response.status_code == 403
-    assert response.headers == {"Content-Type": "text/html"}
-
-
-@mock.patch(f"{MODULE}.get_user_from_token", autospec=True)
-@mock.patch(f"{MODULE}.get_new_token_and_profile", autospec=True)
-@mock.patch(f"{MODULE}.do_auth_and_return", autospec=True)
-def test_handle_auth_bearer_header_no_profile(
-    mock_do_auth_and_return,
-    mock_get_new_token_and_profile,
-    mock_get_user_from_token,
-    current_request
-):
-    current_request.headers = {"x-origin-request-id": "origin_request_id"}
-    mock_response = mock.Mock()
-    mock_do_auth_and_return.return_value = mock_response
-    mock_get_new_token_and_profile.return_value = False
-    mock_get_user_from_token.return_value = "user_name"
-
-    assert app.handle_auth_bearer_header(mock.Mock()) == ("return", mock_response)
-    mock_get_new_token_and_profile.assert_called_once_with(
-        "user_name",
-        True,
-        aux_headers={
-            "x-request-id": "request_1234",
-            "x-origin-request-id": "origin_request_id"
-        }
-    )
-    mock_do_auth_and_return.assert_called_once_with(current_request.context)
-
-
-@mock.patch(f"{MODULE}.get_user_from_token", autospec=True)
-@mock.patch(f"{MODULE}.do_auth_and_return", autospec=True)
-def test_handle_auth_bearer_header_no_user_id(
-    mock_do_auth_and_return,
-    mock_get_user_from_token,
-    current_request
-):
-    current_request.headers = {"x-origin-request-id": "origin_request_id"}
-    mock_response = mock.Mock()
-    mock_do_auth_and_return.return_value = mock_response
-    mock_get_user_from_token.return_value = None
-
-    assert app.handle_auth_bearer_header(mock.Mock()) == ("return", mock_response)
-    mock_do_auth_and_return.assert_called_once_with(current_request.context)
-
-
 @mock.patch(f"{MODULE}.get_yaml_file", autospec=True)
 @mock.patch(f"{MODULE}.try_download_from_bucket", autospec=True)
 @mock.patch(f"{MODULE}.JwtManager.get_profile_from_headers", autospec=True)
@@ -1259,7 +1320,7 @@ def test_dynamic_url_directory(
 @mock.patch(f"{MODULE}.get_yaml_file", autospec=True)
 @mock.patch(f"{MODULE}.try_download_from_bucket", autospec=True)
 @mock.patch(f"{MODULE}.JwtManager.get_profile_from_headers", autospec=True)
-@mock.patch(f"{MODULE}.handle_auth_bearer_header", autospec=True)
+@mock.patch(f"{MODULE}.RequestAuthorizer._handle_auth_bearer_header", autospec=True)
 @mock.patch(f"{MODULE}.JwtManager.get_header_to_set_auth_cookie", autospec=True)
 @mock.patch(f"{MODULE}.JWT_COOKIE_NAME", "asf-cookie")
 def test_dynamic_url_bearer_auth(
@@ -1273,7 +1334,7 @@ def test_dynamic_url_bearer_auth(
     current_request
 ):
     mock_try_download_from_bucket.return_value = chalice.Response(body="Mock response", headers={}, status_code=200)
-    mock_handle_auth_bearer_header.return_value = "user_profile", user_profile
+    mock_handle_auth_bearer_header.return_value = user_profile
     mock_get_header_to_set_auth_cookie.return_value = {"SET-COOKIE": "cookie"}
     with resources.open("bucket_map_example.yaml") as f:
         mock_get_yaml_file.return_value = yaml.full_load(f)
@@ -1330,24 +1391,29 @@ def test_s3credentials(
 
 
 @mock.patch(f"{MODULE}.get_yaml_file", autospec=True)
+@mock.patch(f"{MODULE}.RequestAuthorizer._handle_auth_bearer_header", autospec=True)
 @mock.patch(f"{MODULE}.JwtManager.get_profile_from_headers", autospec=True)
+@mock.patch(f"{MODULE}.do_auth_and_return", autospec=True)
 @mock.patch(f"{MODULE}.b_map", None)
 def test_s3credentials_unauthenticated(
+    mock_do_auth_and_return,
     mock_get_profile,
+    mock_handle_auth_bearer_header,
     mock_get_yaml_file,
-    mock_make_html_response,
     resources,
     client
 ):
+    mock_handle_auth_bearer_header.return_value = None
     with resources.open("bucket_map_example.yaml") as f:
         mock_get_yaml_file.return_value = yaml.full_load(f)
     mock_get_profile.return_value = None
+    mock_response = chalice.Response(body="Mock response", headers={}, status_code=301)
+    mock_do_auth_and_return.return_value = mock_response
 
     response = client.http.get("/s3credentials")
 
-    mock_make_html_response.assert_called_once()
     assert response.body == b"Mock response"
-    assert response.status_code == 401
+    assert response.status_code == 301
 
 
 @mock.patch(f"{MODULE}.boto3")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -44,15 +44,19 @@ def client():
 
 @pytest.fixture
 def lambda_context():
-    with mock.patch(f"{MODULE}.app.lambda_context") as ctx:
-        yield ctx
+    ctx = mock.Mock()
+    app.app.lambda_context = ctx
+    yield ctx
+    del app.app.lambda_context
 
 
 @pytest.fixture
 def current_request(lambda_context):
     lambda_context.aws_request_id = "request_1234"
-    with mock.patch(f"{MODULE}.app.current_request") as req:
-        yield req
+    req = mock.MagicMock()
+    app.app.current_request = req
+    yield req
+    del app.app.current_request
 
 
 @pytest.fixture
@@ -920,7 +924,7 @@ def test_get_bc_config_client_cached(mock_get_new_session_client):
 @mock.patch(f"{MODULE}.JwtManager.get_profile_from_headers", autospec=True)
 @mock.patch(f"{MODULE}.get_bc_config_client", autospec=True)
 @mock.patch(f"{MODULE}.JWT_COOKIE_NAME", "asf-cookie")
-def test_get_data_dl_s3_client(mock_get_bc_config_client, mock_get_profile, user_profile):
+def test_get_data_dl_s3_client(mock_get_bc_config_client, mock_get_profile, user_profile, current_request):
     mock_get_profile.return_value = user_profile
     user_profile.user_id = "username"
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1350,6 +1350,22 @@ def test_s3credentials_unauthenticated(
     assert response.status_code == 401
 
 
+@mock.patch(f"{MODULE}.boto3")
+def test_get_s3_credentials(mock_boto3, monkeypatch):
+    monkeypatch.setenv("EGRESS_APP_DOWNLOAD_ROLE_INREGION_ARN", "aws:role:arn")
+    client = mock_boto3.client("sts")
+
+    app.get_s3_credentials("user", "role-session-name", policy={})
+
+    client.assume_role.assert_called_once_with(
+        RoleArn="aws:role:arn",
+        RoleSessionName="role-session-name",
+        ExternalId="user",
+        DurationSeconds=3600,
+        Policy="{}"
+    )
+
+
 def test_profile(client):
     response = client.http.get("/profile")
 

--- a/tests_e2e/test_s3credentials.py
+++ b/tests_e2e/test_s3credentials.py
@@ -1,0 +1,24 @@
+import requests
+
+
+def test_unauthenticated_user_gets_error(urls):
+    url = urls.join("s3credentials")
+
+    r = requests.get(url)
+
+    assert r.status_code == 401
+
+
+def test_authenticated_user_can_get_creds(urls, auth_cookies):
+    url = urls.join("s3credentials")
+
+    r = requests.get(url, cookies=auth_cookies)
+    data = r.json()
+
+    assert r.status_code == 200
+    assert list(data.keys()) == [
+        "AccessKeyId",
+        "SecretAccessKey",
+        "SessionToken",
+        "Expiration"
+    ]


### PR DESCRIPTION
Adds and endpoint to dispense temporary s3 credentials like the cumulus-distribution module does. One key difference is that I'm calling STS directly from TEA whereas cumulus-distribution goes through the NGAP provided `gsfc-ngap-sh-s3-sts-get-keys` lambda function. I'm not sure why cumulus-distribution uses that lambda, but if we can get away with not calling it then I think that's much preferred as it make the code simpler and probably faster too. Either way we have to support calling sts directly so that TEA can still function outside of NGAP.

TODO:
- [x] Update documentation