### PR TITLE
PR-3244 S3 credential fix

### DIFF
--- a/lambda/app.py
+++ b/lambda/app.py
@@ -1011,7 +1011,10 @@ def get_s3_credentials(user_id: str, role_session_name: str, policy: dict):
         RoleSessionName=role_session_name,
         ExternalId=user_id,
         DurationSeconds=3600,
-        Policy=json.dumps(policy)
+        # NOTE: Policy max size is 2048 characters which is quite limiting.
+        # TODO(reweeden): We'll need to figure out how to accomodate large
+        # bucket maps that will push us over this limit.
+        Policy=json.dumps(policy, separators=(",", ":"))
     )
     return response["Credentials"]
 

--- a/lambda/app.py
+++ b/lambda/app.py
@@ -976,6 +976,19 @@ def s3credentials():
     policy = b_map.to_iam_policy(groups)
     log.debug("policy: %s", policy)
 
+    if policy is None:
+        template_vars = {
+            "contentstring": "You do not have permission to access any data.",
+            "title": "Could not access data",
+            "requestid": get_request_id()
+        }
+        return make_html_response(
+            template_vars,
+            authorizer.get_success_response_headers(),
+            403,
+            "error.html"
+        )
+
     app_name = app.current_request.headers.get("app-name", "")
     role_session_name = get_role_session_name(user_profile.user_id, app_name)
 

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -2,5 +2,5 @@ cachetools
 cfnresponse
 chalice
 flatdict
-git+https://github.com/asfadmin/rain-api-core.git@6acd2cb943cb552c525bc5320297f62b812a33ba
+git+https://github.com/asfadmin/rain-api-core.git@e1638eec08353651ed42105840ba6a80a7141ac2
 netaddr

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -52,7 +52,7 @@ pyyaml==6.0
     # via
     #   chalice
     #   rain-api-core
-rain-api-core @ git+https://github.com/asfadmin/rain-api-core.git@6acd2cb943cb552c525bc5320297f62b812a33ba
+rain-api-core @ git+https://github.com/asfadmin/rain-api-core.git@e1638eec08353651ed42105840ba6a80a7141ac2
     # via -r requirements/requirements.in
 readchar==4.0.3
     # via inquirer


### PR DESCRIPTION
The main fix comes from updating the rain-api-core dependency to the version that will dedupe statement resources