### PR TITLE
Pin ubuntu version in e2e github workflow

### DIFF
--- a/.github/workflows/re-test-e2e.yml
+++ b/.github/workflows/re-test-e2e.yml
@@ -32,7 +32,8 @@ on:
 jobs:
   # Deploy to the test environment and run end to end tests
   test-end-to-end:
-    runs-on: ubuntu-latest
+    # Version of gdal installed depends on ubuntu version
+    runs-on: ubuntu-20.04
     environment: ${{ inputs.environment }}
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
The build breaks on ubuntu 22 because a newer version of gdal is installed which doesn't match the pinned version installed by pip.