### PR TITLE
Fix userid none for public data

### DIFF
--- a/lambda/app.py
+++ b/lambda/app.py
@@ -916,7 +916,7 @@ def dynamic_url():
     log.debug('required_groups: %s', required_groups)
     # Check for public bucket
     timer.mark("possible auth header handling")
-    user_profile = None
+    user_profile = JWT_MANAGER.get_profile_from_headers(app.current_request.headers)
     if required_groups is None:
         log.debug("Accessing public bucket %s => %s", entry.bucket_path, entry.bucket)
     else:

--- a/tests_e2e/test_protected.py
+++ b/tests_e2e/test_protected.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import urllib.parse
 from uuid import uuid1
 
 import pytest
@@ -8,7 +9,7 @@ import requests
 LOCATE_BUCKET = "s1-ocn-1e29d408"
 
 
-def test_urs_auth_redirect_for_auth_downloads(urls, auth_cookies):
+def test_urs_auth_redirect_for_auth_downloads(urls, auth_cookies, urs_username):
     url = urls.join(urls.METADATA_FILE)
 
     r = requests.get(url, cookies=auth_cookies, allow_redirects=False)
@@ -16,6 +17,10 @@ def test_urs_auth_redirect_for_auth_downloads(urls, auth_cookies):
     assert r.status_code == 303
     assert r.is_redirect is True
     assert r.headers['Location'] is not None
+    query_params = urllib.parse.parse_qs(
+        urllib.parse.urlparse(r.headers['Location']).query
+    )
+    assert query_params['A-userid'] == [urs_username]
     assert 'oauth/authorize' not in r.headers['Location']
 
 


### PR DESCRIPTION
When accessing public data the `A-userid` field in the presigned URL which is used for metrics purposes would be set to `None` even if the user was logged in.