### PR TITLE
PR-4048 use devel as default branch

### DIFF
--- a/.github/workflows/deploy-docs-website.yml
+++ b/.github/workflows/deploy-docs-website.yml
@@ -2,7 +2,7 @@ name: Deploy documentation to Github Pages
 on:
   push:
     branches:
-      - master
+      - devel
 
 jobs:
   deploy:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - devel
-      - master
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - devel
-      - master
 
 jobs:
   test:

--- a/README.MD
+++ b/README.MD
@@ -5,7 +5,7 @@
 ![Last Good Build](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fs3.amazonaws.com%2Fasf.public.code%2Fthin-egress-app%2Flastgoodbuild.json)
 [![Last Release](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fs3.amazonaws.com%2Fasf.public.code%2Fthin-egress-app%2Flastrelease.json)]((https://github.com/asfadmin/thin-egress-app/releases/latest))
 ![Test Results](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fs3.amazonaws.com%2Fasf.public.code%2Fthin-egress-app%2Ftestresults.json)
-[![codecov](https://codecov.io/gh/asfadmin/thin-egress-app/branch/master/graph/badge.svg?token=Jd5l4IVpkM)](https://codecov.io/gh/asfadmin/thin-egress-app)
+[![codecov](https://codecov.io/gh/asfadmin/thin-egress-app/branch/devel/graph/badge.svg?token=Jd5l4IVpkM)](https://codecov.io/gh/asfadmin/thin-egress-app)
 [![Safety Badge](https://pyup.io/repos/github/asfadmin/thin-egress-app/shield.svg?t=1559317620375)](https://pyup.io/account/repos/github/asfadmin/thin-egress-app/)
 [![CodeFactor](https://www.codefactor.io/repository/github/asfadmin/thin-egress-app/badge)](https://www.codefactor.io/repository/github/asfadmin/thin-egress-app)
 

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -19,7 +19,7 @@ file, parses out the IP CIDRs for the deploy region, and automatically
 updates the In-Region IAM Role's Policy Document `condition` block.
 
 This lambda is defined in
-[update_lambda.py](https://github.com/asfadmin/thin-egress-app/blob/master/thin_egress_app/update_lambda.py)
+[update_lambda.py](https://github.com/asfadmin/thin-egress-app/blob/devel/thin_egress_app/update_lambda.py)
 
 ## Build Process
 


### PR DESCRIPTION
This should accompany a repo settings change to use `devel` for the default branch. This would make our development workflow a lot less annoying as the default base branch when opening a PR would be the correct branch most of the time.