### PR TITLE
Get session ttl from environment variable

### DIFF
--- a/thin_egress_app/app.py
+++ b/thin_egress_app/app.py
@@ -101,7 +101,8 @@ JWT_MANAGER = JwtManager(
     algorithm=os.getenv('JWT_ALGO', 'RS256'),
     public_key=None,
     private_key=None,
-    cookie_name=os.getenv('JWT_COOKIENAME', JWT_COOKIE_NAME)
+    cookie_name=os.getenv('JWT_COOKIENAME', JWT_COOKIE_NAME),
+    session_ttl_in_hours=int(os.getenv('SESSION_TTL_HRS', 7 * 24)),
 )
 TEMPLATE_MANAGER = TemplateManager(conf_bucket, template_dir)
 


### PR DESCRIPTION
There's a cloudformation parameter for it which sets an environment variable, but we're never reading the variable. Probably this got dropped when we refactored the JWT code.