### PR TITLE
PR-5371 Update all dependencies

### DIFF
--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -4,33 +4,35 @@
 #
 #    pip-compile requirements/requirements-dev.in
 #
-boto3==1.26.153
+boto3==1.28.82
     # via
     #   -r requirements/requirements-dev.in
     #   moto
-botocore==1.29.153
+botocore==1.31.82
     # via
     #   -c requirements/requirements.txt
     #   boto3
     #   moto
     #   s3transfer
-build==0.10.0
+build==1.0.3
     # via pip-tools
-certifi==2023.5.7
+certifi==2023.7.22
     # via requests
-cffi==1.15.1
+cffi==1.16.0
     # via
     #   -c requirements/requirements.txt
     #   cryptography
-charset-normalizer==3.1.0
+charset-normalizer==3.3.2
     # via requests
-click==8.1.3
+click==8.1.7
     # via
     #   -c requirements/requirements.txt
     #   pip-tools
-coverage[toml]==7.2.7
-    # via pytest-cov
-cryptography==41.0.1
+coverage[toml]==7.3.2
+    # via
+    #   coverage
+    #   pytest-cov
+cryptography==41.0.5
     # via
     #   -c requirements/requirements.txt
     #   moto
@@ -38,12 +40,14 @@ deprecated==1.2.14
     # via opentelemetry-api
 docker==6.1.3
     # via moto
-exceptiongroup==1.1.1
+exceptiongroup==1.1.3
     # via pytest
 idna==3.4
     # via requests
-importlib-metadata==6.0.1
-    # via opentelemetry-api
+importlib-metadata==6.8.0
+    # via
+    #   build
+    #   opentelemetry-api
 iniconfig==2.0.0
     # via pytest
 jinja2==3.1.2
@@ -60,20 +64,20 @@ markupsafe==2.1.3
     #   -c requirements/requirements.txt
     #   jinja2
     #   werkzeug
-moto[awslambda]==4.1.11
+moto[awslambda]==4.2.7
     # via -r requirements/requirements-dev.in
-opentelemetry-api==1.18.0
+opentelemetry-api==1.21.0
     # via opentelemetry-instrumentation
-opentelemetry-instrumentation==0.39b0
+opentelemetry-instrumentation==0.42b0
     # via -r requirements/requirements-dev.in
-packaging==23.1
+packaging==23.2
     # via
     #   build
     #   docker
     #   pytest
-pip-tools==6.13.0
+pip-tools==7.3.0
     # via -r requirements/requirements-dev.in
-pluggy==1.0.0
+pluggy==1.3.0
     # via pytest
 pycparser==2.21
     # via
@@ -81,7 +85,7 @@ pycparser==2.21
     #   cffi
 pyproject-hooks==1.0.0
     # via build
-pytest==7.3.2
+pytest==7.4.3
     # via
     #   -r requirements/requirements-dev.in
     #   pytest-cov
@@ -92,7 +96,7 @@ python-dateutil==2.8.2
     #   -c requirements/requirements.txt
     #   botocore
     #   moto
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -c requirements/requirements.txt
     #   -r requirements/requirements-dev.in
@@ -102,9 +106,9 @@ requests==2.31.0
     #   docker
     #   moto
     #   responses
-responses==0.23.1
+responses==0.24.0
     # via moto
-s3transfer==0.6.1
+s3transfer==0.7.0
     # via boto3
 six==1.16.0
     # via
@@ -114,32 +118,31 @@ tomli==2.0.1
     # via
     #   build
     #   coverage
+    #   pip-tools
     #   pyproject-hooks
     #   pytest
-types-pyyaml==6.0.12.10
-    # via responses
-urllib3==1.26.16
+urllib3==1.26.18
     # via
     #   -c requirements/requirements.txt
     #   botocore
     #   docker
     #   requests
     #   responses
-websocket-client==1.5.3
+websocket-client==1.6.4
     # via docker
-werkzeug==2.3.6
+werkzeug==3.0.1
     # via moto
-wheel==0.40.0
+wheel==0.41.3
     # via
     #   -c requirements/requirements.txt
     #   pip-tools
-wrapt==1.15.0
+wrapt==1.16.0
     # via
     #   deprecated
     #   opentelemetry-instrumentation
 xmltodict==0.13.0
     # via moto
-zipp==3.15.0
+zipp==3.17.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/requirements-docs.txt
+++ b/requirements/requirements-docs.txt
@@ -4,54 +4,82 @@
 #
 #    pip-compile requirements/requirements-docs.in
 #
-click==8.1.3
+babel==2.13.1
+    # via mkdocs-material
+certifi==2023.7.22
+    # via requests
+charset-normalizer==3.3.2
+    # via requests
+click==8.1.7
     # via mkdocs
+colorama==0.4.6
+    # via mkdocs-material
 ghp-import==2.1.0
     # via mkdocs
-importlib-metadata==6.6.0
+idna==3.4
+    # via requests
+importlib-metadata==6.8.0
     # via
     #   markdown
     #   mkdocs
 jinja2==3.1.2
-    # via mkdocs
-markdown==3.3.7
+    # via
+    #   mkdocs
+    #   mkdocs-material
+markdown==3.5.1
     # via
     #   mkdocs
     #   mkdocs-material
     #   pymdown-extensions
 markupsafe==2.1.3
-    # via jinja2
+    # via
+    #   jinja2
+    #   mkdocs
 mergedeep==1.3.4
     # via mkdocs
-mkdocs==1.4.3
+mkdocs==1.5.3
     # via
     #   -r requirements/requirements-docs.in
     #   mkdocs-asf-theme
     #   mkdocs-material
-mkdocs-asf-theme==0.2.4
+mkdocs-asf-theme==0.3.0
     # via -r requirements/requirements-docs.in
-mkdocs-material==6.2.8
+mkdocs-material==9.4.8
     # via mkdocs-asf-theme
-mkdocs-material-extensions==1.1.1
+mkdocs-material-extensions==1.3
     # via mkdocs-material
-packaging==23.1
+packaging==23.2
     # via mkdocs
-pygments==2.15.1
+paginate==0.5.6
     # via mkdocs-material
-pymdown-extensions==10.0.1
+pathspec==0.11.2
+    # via mkdocs
+platformdirs==3.11.0
+    # via mkdocs
+pygments==2.16.1
+    # via mkdocs-material
+pymdown-extensions==10.3.1
     # via mkdocs-material
 python-dateutil==2.8.2
     # via ghp-import
-pyyaml==6.0
+pytz==2023.3.post1
+    # via babel
+pyyaml==6.0.1
     # via
     #   mkdocs
     #   pymdown-extensions
     #   pyyaml-env-tag
 pyyaml-env-tag==0.1
     # via mkdocs
+regex==2023.10.3
+    # via mkdocs-material
+requests==2.31.0
+    # via mkdocs-material
 six==1.16.0
     # via python-dateutil
+urllib3==2.0.7
+    # via requests
 watchdog==3.0.0
     # via mkdocs
-zipp==3.15.0
+zipp==3.17.0
     # via importlib-metadata

--- a/requirements/requirements-make.txt
+++ b/requirements/requirements-make.txt
@@ -4,21 +4,21 @@
 #
 #    pip-compile requirements/requirements-make.in
 #
-importlib-metadata==6.6.0
+importlib-metadata==6.8.0
     # via markdown
 jinja2==3.1.2
     # via -r requirements/requirements-make.in
-markdown==3.4.3
+markdown==3.5.1
     # via
     #   -r requirements/requirements-make.in
     #   pymdown-extensions
 markupsafe==2.1.3
     # via jinja2
-pygments==2.15.1
+pygments==2.16.1
     # via -r requirements/requirements-make.in
-pymdown-extensions==10.0.1
+pymdown-extensions==10.3.1
     # via -r requirements/requirements-make.in
-pyyaml==6.0
+pyyaml==6.0.1
     # via pymdown-extensions
-zipp==3.15.0
+zipp==3.17.0
     # via importlib-metadata

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -4,17 +4,17 @@
 #
 #    pip-compile requirements/requirements-test.in
 #
-boto3==1.26.153
+boto3==1.28.82
     # via -r requirements/requirements-test.in
-botocore==1.29.153
+botocore==1.31.82
     # via
     #   boto3
     #   s3transfer
-certifi==2023.5.7
+certifi==2023.7.22
     # via requests
-charset-normalizer==3.1.0
+charset-normalizer==3.3.2
     # via requests
-exceptiongroup==1.1.1
+exceptiongroup==1.1.3
     # via pytest
 idna==3.4
     # via requests
@@ -24,25 +24,25 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-packaging==23.1
+packaging==23.2
     # via pytest
-pluggy==1.0.0
+pluggy==1.3.0
     # via pytest
-pytest==7.3.2
+pytest==7.4.3
     # via -r requirements/requirements-test.in
 python-dateutil==2.8.2
     # via botocore
-pyyaml==6.0
+pyyaml==6.0.1
     # via -r requirements/requirements-test.in
 requests==2.31.0
     # via -r requirements/requirements-test.in
-s3transfer==0.6.1
+s3transfer==0.7.0
     # via boto3
 six==1.16.0
     # via python-dateutil
 tomli==2.0.1
     # via pytest
-urllib3==1.26.16
+urllib3==1.26.18
     # via
     #   botocore
     #   requests

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,21 +6,21 @@
 #
 blessed==1.20.0
     # via inquirer
-botocore==1.29.153
+botocore==1.31.82
     # via chalice
 cachetools==5.0.0
     # via
     #   -r requirements/requirements.in
     #   rain-api-core
-cffi==1.15.1
+cffi==1.16.0
     # via cryptography
 cfnresponse==1.1.2
     # via -r requirements/requirements.in
 chalice==1.29.0
     # via -r requirements/requirements.in
-click==8.1.3
+click==8.1.7
     # via chalice
-cryptography==41.0.1
+cryptography==41.0.5
     # via pyjwt
 flatdict==4.0.1
     # via -r requirements/requirements.in
@@ -34,19 +34,21 @@ jmespath==1.0.1
     #   chalice
 markupsafe==2.1.3
     # via jinja2
-netaddr==0.8.0
+netaddr==0.9.0
     # via
     #   -r requirements/requirements.in
     #   rain-api-core
 pycparser==2.21
     # via cffi
-pyjwt[crypto]==2.7.0
-    # via rain-api-core
+pyjwt[crypto]==2.8.0
+    # via
+    #   pyjwt
+    #   rain-api-core
 python-dateutil==2.8.2
     # via botocore
 python-editor==1.0.4
     # via inquirer
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   chalice
     #   rain-api-core
@@ -59,15 +61,15 @@ six==1.16.0
     #   blessed
     #   chalice
     #   python-dateutil
-typing-extensions==4.6.3
+typing-extensions==4.8.0
     # via chalice
-urllib3==1.26.16
+urllib3==1.26.18
     # via
     #   botocore
     #   cfnresponse
-wcwidth==0.2.6
+wcwidth==0.2.9
     # via blessed
-wheel==0.40.0
+wheel==0.41.3
     # via chalice
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
The mkdocs ASF theme was updated in https://github.com/ASFHyP3/mkdocs-asf-theme/issues/27 to support the latest version of mkdocs material, so this should address the warnings about the outdated version of mkdocs material.