### PR TITLE
PR-5069 Refactor locate endpoint

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,6 +1,5 @@
 cachetools
 cfnresponse
 chalice
-flatdict
 git+https://github.com/asfadmin/rain-api-core.git@318aac226c92cf6f60cc8821d6d94669485972c6
 netaddr

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -22,8 +22,6 @@ click==8.1.7
     # via chalice
 cryptography==41.0.7
     # via pyjwt
-flatdict==4.0.1
-    # via -r requirements/requirements.in
 inquirer==2.10.1
     # via chalice
 jinja2==3.1.2

--- a/tests/data/old_style_bucket_map_example.yaml
+++ b/tests/data/old_style_bucket_map_example.yaml
@@ -1,0 +1,33 @@
+RAW:
+  PLATFORM-A:         pa-raw
+  PLATFORM-B:         pb-raw
+DATA-TYPE-1:
+  PLATFORM-A:         pa-dt1
+  PLATFORM-B:         pb-dt1
+BROWSE:
+  PLATFORM-A:         pa-bro
+  PLATFORM-B:         pb-bro
+PRIVATE:
+  PLATFORM-A:         pa-priv
+  PLATFORM-B:         pb-priv
+HEADERS:
+  BROWSE:
+    bucket: pa-bro
+    headers:
+      custom-header-1: custom-header-1-value
+      custom-header-2: custom-header-2-value
+  PRIVATE:
+    bucket: pa-priv
+    headers:
+      custom-header-3: custom-header-3-value
+      custom-header-4: custom-header-4-value
+
+PUBLIC_BUCKETS:
+  - pa-bro
+  - pb-bro
+
+PRIVATE_BUCKETS:
+  pa-priv:
+    - PRIVATE_GROUP_A
+  pb-priv:
+    - PRIVATE_GROUP_B

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -569,6 +569,7 @@ def test_get_user_ip(current_request):
 @mock.patch(f"{MODULE}.get_role_creds", autospec=True)
 @mock.patch(f"{MODULE}.get_role_session", autospec=True)
 @mock.patch(f"{MODULE}.get_presigned_url", autospec=True)
+@mock.patch(f"{MODULE}.b_map", None)
 def test_try_download_from_bucket(
     mock_get_presigned_url,
     mock_get_role_session,
@@ -587,7 +588,6 @@ def test_try_download_from_bucket(
     client = mock_get_role_session().client()
     client.get_bucket_location.return_value = {"LocationConstraint": "us-east-1"}
     client.head_object.return_value = {"ContentLength": 2048}
-    app.b_map = None
 
     response = app.try_download_from_bucket("somebucket", "somefile", user_profile, {})
     client.head_object.assert_called_once()
@@ -1152,7 +1152,6 @@ def test_dynamic_url(
 
     mock_get_profile.return_value = user_profile
     current_request.uri_params = {"proxy": "DATA-TYPE-1/PLATFORM-A/OBJECT_1"}
-    app.b_map = None
 
     # Can't use the chalice test client here as it doesn't seem to understand the `{proxy+}` route
     response = app.dynamic_url()
@@ -1445,6 +1444,7 @@ def test_dynamic_url_directory(
 @mock.patch(f"{MODULE}.RequestAuthorizer._handle_auth_bearer_header", autospec=True)
 @mock.patch(f"{MODULE}.JwtManager.get_header_to_set_auth_cookie", autospec=True)
 @mock.patch(f"{MODULE}.JWT_COOKIE_NAME", "asf-cookie")
+@mock.patch(f"{MODULE}.b_map", None)
 def test_dynamic_url_bearer_auth(
     mock_get_header_to_set_auth_cookie,
     mock_handle_auth_bearer_header,


### PR DESCRIPTION
The `/locate` endpoint seems to be the last place that had special handling code to interact with the bucket map that was not going through the `BucketMap` class. This change will ensure that the bucket map behavior is consistent for `/locate` and other functionality. Specifically, this allows the old-style bucket maps with no top level `MAP` key to work with `/locate` (previously a 500 error would be returned).