### PR TITLE
Fix docs build

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,11 @@ repo_url: https://github.com/asfadmin/thin-egress-app
 repo_name: thin-egress-app
 edit_uri: ''
 
+extra:
+  social:
+    - icon: fontawesome/brands/gitter
+      link: https://gitter.im/ASFHyP3/community
+
 nav:
   - Home: index.md
   - Vision: vision.md


### PR DESCRIPTION
The `mkdocs-asf-theme` template does not treat the `extra.social` section as optional. As such, rendering will crash if it's missing from the `mkdocs.yml`. This section of the config is copied from the hyp3 docs.