### PR TITLE
Fix locate endpoint bucket name test

### DIFF
--- a/.github/workflows/re-test-e2e.yml
+++ b/.github/workflows/re-test-e2e.yml
@@ -159,7 +159,7 @@ jobs:
                   LambdaCodeS3Bucket="$CODE_BUCKET" \
                   LambdaCodeS3Key="${CODE_PREFIX}${CODE_NAME}" \
                   LambdaMemory="128" \
-                  LambdaTimeout="10" \
+                  LambdaTimeout="20" \
                   Loglevel="DEBUG" \
                   Logtype="json" \
                   Maturity="TEST"\

--- a/tests_e2e/test_protected.py
+++ b/tests_e2e/test_protected.py
@@ -6,7 +6,7 @@ from uuid import uuid1
 import pytest
 import requests
 
-LOCATE_BUCKET = "s1-ocn-1e29d408"
+LOCATE_BUCKET = "rain-uw2-t-s1-ocn-1e29d408"
 
 
 def test_urs_auth_redirect_for_auth_downloads(urls, auth_cookies, urs_username):


### PR DESCRIPTION
#777 introduced a change to how the locate endpoint works with respect to the `BucketnamePrefix` parameter. Previously the `bucket` parameter expected the name of the bucket WITHOUT the prefix. This is arguably not the desired behavior as it requires the caller of the application to know which part of the bucket name is the prefix and to be able to strip it out in the request. However, this does create a breaking change in the API so we have a few options:

1. Bump the version number to 2.x to reflect the fact that this is a breaking change.
2. Decide that the old behavior was a bug and therefore we only bump the bugfix number 1.3.x. *This is probably not the best option because it's possible that there are some TEA deployments out there that might be affected by this*.
3. Support both for a while before dropping support for the old behavior. *This still requires doing option 1 at some point in the future but just kicks that to a later date. I don't think there's realistically any benefit to doing that over just bumping the version number now.*

I think option 1 is the way to go for now. Even though this is a breaking change, AFAIK CIRRUS/cumulus doesn't use the `BucketnamePrefix` parameter, so those deployments won't be affected and Sentinel doesn't use the `locate` endpoint so those deployments shouldn't be affected either. If there are some affected deployments out there they'll have the warning of the version number bump and they can ask for support in upgrading.