### PR TITLE
PR-5790 Add CORS preflight OPTIONS request

### DIFF
--- a/tests_e2e/test_cors.py
+++ b/tests_e2e/test_cors.py
@@ -51,8 +51,9 @@ def test_cors_preflight_options(urls, auth_cookies):
     headers = dict(r.headers)
 
     assert r.status_code == 204
-    assert headers.get("Access-Control-Allow-Origin") == origin_host
-    assert "GET" in headers.get("Access-Control-Allow-Methods")
+    assert headers["Access-Control-Allow-Origin"] == origin_host
+    assert set(headers["Access-Control-Allow-Methods"].split(", ")) >= {"GET", "HEAD", "OPTIONS"}
+    assert set(headers["Access-Control-Allow-Headers"].split(", ")) >= {"Authorization", "Origin"}
 
 
 def test_cors_preflight_options_origin_null(urls, auth_cookies):
@@ -71,5 +72,6 @@ def test_cors_preflight_options_origin_null(urls, auth_cookies):
     headers = dict(r.headers)
 
     assert r.status_code == 204
-    assert headers.get("Access-Control-Allow-Origin") == "null"
-    assert "GET" in headers.get("Access-Control-Allow-Methods")
+    assert headers["Access-Control-Allow-Origin"] == "null"
+    assert set(headers["Access-Control-Allow-Methods"].split(", ")) >= {"GET", "HEAD", "OPTIONS"}
+    assert set(headers["Access-Control-Allow-Headers"].split(", ")) >= {"Authorization", "Origin"}

--- a/tests_e2e/test_cors.py
+++ b/tests_e2e/test_cors.py
@@ -5,16 +5,71 @@ def test_cors(urls, auth_cookies):
     origin_host = "https://something.asf.alaska.edu"
 
     url = urls.join(urls.METADATA_FILE_CH)
-    origin_headers = {"origin": origin_host}
+    request_headers = {"origin": origin_host}
 
-    r = requests.get(url, cookies=auth_cookies, headers=origin_headers, allow_redirects=False)
+    r = requests.get(
+        url,
+        cookies=auth_cookies,
+        headers=request_headers,
+        allow_redirects=False,
+    )
     headers = dict(r.headers)
 
     assert headers.get("Access-Control-Allow-Origin") == origin_host
     assert headers.get("Access-Control-Allow-Credentials") == "true"
 
-    headers = {"origin": "null"}
-    r = requests.get(url, cookies=auth_cookies, headers=headers, allow_redirects=False)
+
+def test_cors_origin_null(urls, auth_cookies):
+    url = urls.join(urls.METADATA_FILE_CH)
+    request_headers = {"origin": "null"}
+    r = requests.get(
+        url,
+        cookies=auth_cookies,
+        headers=request_headers,
+        allow_redirects=False,
+    )
     headers = dict(r.headers)
 
     assert headers.get("Access-Control-Allow-Origin") == "null"
+
+
+def test_cors_preflight_options(urls, auth_cookies):
+    origin_host = "https://something.asf.alaska.edu"
+
+    url = urls.join(urls.METADATA_FILE_CH)
+    request_headers = {
+        "Origin": origin_host,
+        "Access-Control-Request-Method": "GET"
+    }
+
+    r = requests.options(
+        url,
+        cookies=auth_cookies,
+        headers=request_headers,
+        allow_redirects=False,
+    )
+    headers = dict(r.headers)
+
+    assert r.status_code == 204
+    assert headers.get("Access-Control-Allow-Origin") == origin_host
+    assert "GET" in headers.get("Access-Control-Allow-Methods")
+
+
+def test_cors_preflight_options_origin_null(urls, auth_cookies):
+    url = urls.join(urls.METADATA_FILE_CH)
+    request_headers = {
+        "Origin": "null",
+        "Access-Control-Request-Method": "GET"
+    }
+
+    r = requests.options(
+        url,
+        cookies=auth_cookies,
+        headers=request_headers,
+        allow_redirects=False,
+    )
+    headers = dict(r.headers)
+
+    assert r.status_code == 204
+    assert headers.get("Access-Control-Allow-Origin") == "null"
+    assert "GET" in headers.get("Access-Control-Allow-Methods")


### PR DESCRIPTION
Some libraries will automatically make this `OPTIONS` request and we need to respond with the appropriate headers to prevent cross origin requests from being blocked.