### PR TITLE
Fix Terraform updating dependency layer object when content hasn't changed

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -27,6 +27,7 @@ resource "aws_s3_object" "lambda_source" {
   key         = "${filemd5(local.lambda_source_filename)}.zip"
   source      = local.lambda_source_filename
   source_hash = filemd5(local.lambda_source_filename)
+  tags        = var.tags
 }
 
 resource "aws_s3_object" "lambda_code_dependency_archive" {
@@ -34,6 +35,7 @@ resource "aws_s3_object" "lambda_code_dependency_archive" {
   key         = "${filemd5(local.dependency_layer_filename)}.zip"
   source      = local.dependency_layer_filename
   source_hash = filemd5(local.dependency_layer_filename)
+  tags        = var.tags
 }
 
 resource "aws_s3_object" "cloudformation_template" {
@@ -41,6 +43,7 @@ resource "aws_s3_object" "cloudformation_template" {
   key         = "${filemd5(local.cloudformation_template_filename)}.yaml"
   source      = local.cloudformation_template_filename
   source_hash = filemd5(local.cloudformation_template_filename)
+  tags        = var.tags
 }
 
 resource "aws_cloudformation_stack" "thin_egress_app" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -23,24 +23,24 @@ resource "aws_s3_bucket" "lambda_source" {
 }
 
 resource "aws_s3_object" "lambda_source" {
-  bucket = aws_s3_bucket.lambda_source.bucket
-  key    = "${filemd5(local.lambda_source_filename)}.zip"
-  source = local.lambda_source_filename
-  etag   = filemd5(local.lambda_source_filename)
+  bucket      = aws_s3_bucket.lambda_source.bucket
+  key         = "${filemd5(local.lambda_source_filename)}.zip"
+  source      = local.lambda_source_filename
+  source_hash = filemd5(local.lambda_source_filename)
 }
 
 resource "aws_s3_object" "lambda_code_dependency_archive" {
-  bucket = aws_s3_bucket.lambda_source.bucket
-  key    = "${filemd5(local.dependency_layer_filename)}.zip"
-  source = local.dependency_layer_filename
-  etag   = filemd5(local.dependency_layer_filename)
+  bucket      = aws_s3_bucket.lambda_source.bucket
+  key         = "${filemd5(local.dependency_layer_filename)}.zip"
+  source      = local.dependency_layer_filename
+  source_hash = filemd5(local.dependency_layer_filename)
 }
 
 resource "aws_s3_object" "cloudformation_template" {
-  bucket = aws_s3_bucket.lambda_source.bucket
-  key    = "${filemd5(local.cloudformation_template_filename)}.yaml"
-  source = local.cloudformation_template_filename
-  etag   = filemd5(local.cloudformation_template_filename)
+  bucket      = aws_s3_bucket.lambda_source.bucket
+  key         = "${filemd5(local.cloudformation_template_filename)}.yaml"
+  source      = local.cloudformation_template_filename
+  source_hash = filemd5(local.cloudformation_template_filename)
 }
 
 resource "aws_cloudformation_stack" "thin_egress_app" {


### PR DESCRIPTION
While doing Cumulus upgrades, I noticed that on every update Terraform was adding something like this to the plan:

```
 # module.thin_egress_app.aws_s3_bucket_object.lambda_code_dependency_archive will be updated in-place
  ~ resource "aws_s3_bucket_object" "lambda_code_dependency_archive" {
      ~ etag                          = "661d0e0eb0bc955857a7a71087a4208a-2" -> "96bac3b47b39d00107729959bc6689d3"
        id                            = "96bac3b47b39d00107729959bc6689d3.zip"
        tags                          = {}
      + version_id                    = (known after apply)
        # (20 unchanged attributes hidden)
    }
```

The [etag](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object#etag) attribute has a warning about using it for files larger than 16MB as it can cause this behavior where the etag after uploading with a multipart upload does not match the full source code hash causing Terraform to needlessly update the object.

While I was at it I also applied the `tags` variable to the bucket objects as well.