### PR TITLE
PR-3242 Improve handling of JWT bearer tokens

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -2,5 +2,6 @@
 cachetools
 cfnresponse
 chalice
-git+https://github.com/asfadmin/rain-api-core.git@1be67560f7c41b50afbd2ca20473ffbdc7efae68
+git+https://github.com/asfadmin/rain-api-core.git@8d241610b50299198aa0cc210852259fef9e482b
 netaddr
+pyjwt

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -41,14 +41,16 @@ netaddr==1.3.0
 pycparser==2.22
     # via cffi
 pyjwt[crypto]==2.10.1
-    # via rain-api-core
+    # via
+    #   -r requirements/requirements.in
+    #   rain-api-core
 python-dateutil==2.9.0.post0
     # via botocore
 pyyaml==6.0.2
     # via
     #   chalice
     #   rain-api-core
-rain-api-core @ git+https://github.com/asfadmin/rain-api-core.git@1be67560f7c41b50afbd2ca20473ffbdc7efae68
+rain-api-core @ git+https://github.com/asfadmin/rain-api-core.git@8d241610b50299198aa0cc210852259fef9e482b
     # via -r requirements/requirements.in
 readchar==4.2.1
     # via inquirer

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import textwrap
 from pathlib import Path
 
 import boto3
@@ -24,6 +25,25 @@ def aws_credentials():
     os.environ["AWS_SECURITY_TOKEN"] = "testing"
     os.environ["AWS_SESSION_TOKEN"] = "testing"
     os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+
+@pytest.fixture(scope="session")
+def private_key():
+    """Used for signing fake JWTs in unit tests"""
+    return textwrap.dedent(
+        """
+        -----BEGIN PRIVATE KEY-----
+        MIIBVQIBADANBgkqhkiG9w0BAQEFAASCAT8wggE7AgEAAkEAzXKhtCOkUvA5POUW
+        ddN8G0wHTQfQg6wp7NXmID8AW0FMU5ZOhAl0l1dGWs9U83C4IA8Hqbpe/XbY8CuT
+        SOEWUwIDAQABAkAU5/5Wg238Vp+sd69ybAPsDy+LAimQzJszk4yoaWDS6EI1DcBV
+        npb7lFvGCcnUe57Lm6DhWD1EnDYhD451VrYRAiEA/8z3pXYDBSJoWA79xrsq2cze
+        4oYwhTWtzueU8+Mlf0kCIQDNm55qR00BUbhBO/tTP2VCC2OQd/v9I+UIcwIL9Wg8
+        uwIhAOpwUAe1QM9T2Y3bL3sTzxIOUbgKhC2SJNmcJUfgxl0BAiEAq+nbageV9m1q
+        v3i0qqWON8uoAyqfkshJf2gSJQebkXMCIFUVSih1R6FqkoP2HFOZvJiRQnfO6shL
+        jrhQOs2SXP05
+        -----END PRIVATE KEY-----
+        """,
+    )
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Replaces the old bearer token logic with updated handling for JWT bearer tokens. The user_id is extracted from the bearer token directly, eliminating 1 call to EDL, and then the token is used to fetch the user profile, simultaneously verifying the validity of the token and returning the profile information. That eliminates another EDL call for fetching an application bearer token.

TODO: 
- https://github.com/asfadmin/rain-api-core/pull/297