### PR TITLE
Add error handling for malformed auth headers

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -166,6 +166,22 @@ def test_request_authorizer_no_headers(current_request, mock_get_urs_url):
     assert authorizer.get_success_response_headers() == {}
 
 
+def test_request_authorizer_malformed_header(current_request):
+    current_request.headers = {
+        "Authorization": "token",
+        "x-origin-request-id": "origin_request_id",
+    }
+    authorizer = app.RequestAuthorizer()
+
+    assert authorizer.get_profile() is None
+    response = authorizer.get_error_response()
+    assert response.status_code == 400
+    assert response.body == {
+        "status_code": 400,
+        "error_description": "Malformed Authorization header",
+    }
+
+
 @mock.patch(f"{MODULE}.get_profile_with_jwt_bearer", autospec=True)
 def test_request_authorizer_bearer_header(
     mock_get_profile_with_jwt_bearer,


### PR DESCRIPTION
Currently if we send an auth header without the string `Bearer` we'll see an error like this:
```
$ curl -X GET --header "Authorization: foobar" http://...
{"Code":"InternalServerError","Message":"An internal server error occurred."}
```

With these changes:
```
$ curl -X GET --header "Authorization: foobar" http://...
{"status_code":400,"error_description":"Malformed Authorization header"}
```

NOTE: CMR accepts an authorization header containing just the token, so it is reasonable that some users might see that and try the same approach with TEA.