### PR TITLE
Add policy sandbox from rain-api-core to tea-cli

### DIFF
--- a/src/tea-cli/pyproject.toml
+++ b/src/tea-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "tea-cli"
-version = "0.1.2"
+version = "0.1.3"
 description = "TEA command line tool"
 authors = ["Rohan Weeden <reweeden@alaska.edu>"]
 license = "Apache-2.0"
@@ -17,6 +17,7 @@ tea = "tea_cli:main.main"
 python = "^3.10"
 boto3 = "^1.26.163"
 cryptography = "^46.0.1"
+rain-api-core = {git = "https://github.com/asfadmin/rain-api-core.git", rev = "9637b7d"}
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"

--- a/src/tea-cli/tea_cli/commands/policy_sandbox.py
+++ b/src/tea-cli/tea_cli/commands/policy_sandbox.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import tkinter as tk
+import tkinter.font
 import traceback
 
 import yaml
@@ -36,11 +37,34 @@ def policy_sandbox():
     window.columnconfigure(0, weight=1)
     window.rowconfigure(0, weight=1)
 
+    menubar = tk.Menu()
+    window.config(menu=menubar)
+
     frm_content = tk.Frame(window)
     frm_content.columnconfigure(0, weight=1)
     frm_content.columnconfigure(1, weight=1)
     frm_content.rowconfigure(1, weight=1)
     frm_content.grid(row=0, column=0, sticky="nsew")
+
+    font = tk.font.Font(family="Courier", size=14)
+
+    file_menu = tk.Menu(menubar)
+    file_menu.add_command(
+        label="Exit",
+        command=window.destroy,
+    )
+    menubar.add_cascade(label="File", menu=file_menu)
+
+    view_menu = tk.Menu(menubar)
+    view_menu.add_command(
+        label="Increate font size",
+        command=lambda: font.configure(size=font.cget("size") + 1),
+    )
+    view_menu.add_command(
+        label="Decrease font size",
+        command=lambda: font.configure(size=font.cget("size") - 1),
+    )
+    menubar.add_cascade(label="View", menu=view_menu)
 
     def handle_text():
         text = txt_bucketmap.get("1.0", tk.END).strip()
@@ -66,25 +90,25 @@ def policy_sandbox():
             var_size.set("0")
 
     # Bucket map panel
-    tk.Label(frm_content, text="Bucket map YAML").grid(row=0, column=0)
+    tk.Label(frm_content, text="Bucket map YAML", font=font).grid(row=0, column=0)
 
-    txt_bucketmap = tk.Text(frm_content)
+    txt_bucketmap = tk.Text(frm_content, font=font)
     txt_bucketmap.bind("<Key>", lambda _: window.after(1, handle_text))
     txt_bucketmap.grid(row=1, column=0, sticky="nsew")
 
     # Policy panel
-    tk.Label(frm_content, text="Policy JSON").grid(row=0, column=1)
+    tk.Label(frm_content, text="Policy JSON", font=font).grid(row=0, column=1)
 
-    txt_policy = tk.Text(frm_content)
+    txt_policy = tk.Text(frm_content, font=font)
     txt_policy.grid(row=1, column=1, sticky="nsew")
 
     # Group selector
     frm_groups = tk.Frame(frm_content)
     frm_groups.grid(row=2, column=0)
 
-    tk.Label(frm_groups, text="User Groups: ").grid(row=0, column=0)
+    tk.Label(frm_groups, text="User Groups: ", font=font).grid(row=0, column=0)
     var_group = tk.StringVar(value="null")
-    entry_groups = tk.Entry(frm_groups, textvariable=var_group)
+    entry_groups = tk.Entry(frm_groups, textvariable=var_group, font=font)
     entry_groups.bind("<Key>", lambda _: window.after(1, handle_text))
     entry_groups.grid(row=0, column=1)
 
@@ -92,12 +116,12 @@ def policy_sandbox():
     frm_size = tk.Frame(frm_content)
     frm_size.grid(row=2, column=1)
 
-    tk.Label(frm_size, text="Minified Size: ").grid(row=0, column=0)
+    tk.Label(frm_size, text="Minified Size: ", font=font).grid(row=0, column=0)
 
     var_size = tk.StringVar(value="0")
-    tk.Label(frm_size, textvariable=var_size).grid(row=0, column=1)
+    tk.Label(frm_size, textvariable=var_size, font=font).grid(row=0, column=1)
 
-    tk.Label(frm_size, text=" (max 2048)").grid(row=0, column=2)
+    tk.Label(frm_size, text=" (max 2048)", font=font).grid(row=0, column=2)
 
     handle_text()
     window.mainloop()

--- a/src/tea-cli/tea_cli/commands/policy_sandbox.py
+++ b/src/tea-cli/tea_cli/commands/policy_sandbox.py
@@ -1,0 +1,103 @@
+import argparse
+import json
+import tkinter as tk
+import traceback
+
+import yaml
+from rain_api_core.bucket_map import BucketMap
+
+
+def main(args=None):
+    parser = get_parser()
+
+    parsed_args = parser.parse_args(args)
+    handle_args(parsed_args)
+
+
+def get_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+
+    configure_parser(parser)
+
+    return parser
+
+
+def configure_parser(parser: argparse.ArgumentParser):
+    pass
+
+
+def handle_args(args: argparse.Namespace):
+    policy_sandbox()
+
+
+def policy_sandbox():
+    window = tk.Tk()
+    window.title("IAM Policy Generator Sandbox")
+    window.columnconfigure(0, weight=1)
+    window.rowconfigure(0, weight=1)
+
+    frm_content = tk.Frame(window)
+    frm_content.columnconfigure(0, weight=1)
+    frm_content.columnconfigure(1, weight=1)
+    frm_content.rowconfigure(1, weight=1)
+    frm_content.grid(row=0, column=0, sticky="nsew")
+
+    def handle_text():
+        text = txt_bucketmap.get("1.0", tk.END).strip()
+        try:
+            groups = yaml.safe_load(var_group.get())
+            if not text:
+                bucket_map = {}
+            else:
+                bucket_map = yaml.safe_load(text)
+            b_map = BucketMap(bucket_map)
+
+            policy = b_map.to_iam_policy(groups)
+            policy_text = json.dumps(policy, indent=2)
+            txt_policy.delete("1.0", tk.END)
+            txt_policy.insert(tk.END, policy_text)
+
+            minified_policy_text = json.dumps(policy, separators=(":", ","))
+            var_size.set(str(len(minified_policy_text)))
+        except Exception:
+            exc_text = traceback.format_exc()
+            txt_policy.delete("1.0", tk.END)
+            txt_policy.insert(tk.END, exc_text)
+            var_size.set("0")
+
+    # Bucket map panel
+    tk.Label(frm_content, text="Bucket map YAML").grid(row=0, column=0)
+
+    txt_bucketmap = tk.Text(frm_content)
+    txt_bucketmap.bind("<Key>", lambda _: window.after(1, handle_text))
+    txt_bucketmap.grid(row=1, column=0, sticky="nsew")
+
+    # Policy panel
+    tk.Label(frm_content, text="Policy JSON").grid(row=0, column=1)
+
+    txt_policy = tk.Text(frm_content)
+    txt_policy.grid(row=1, column=1, sticky="nsew")
+
+    # Group selector
+    frm_groups = tk.Frame(frm_content)
+    frm_groups.grid(row=2, column=0)
+
+    tk.Label(frm_groups, text="User Groups: ").grid(row=0, column=0)
+    var_group = tk.StringVar(value="null")
+    entry_groups = tk.Entry(frm_groups, textvariable=var_group)
+    entry_groups.bind("<Key>", lambda _: window.after(1, handle_text))
+    entry_groups.grid(row=0, column=1)
+
+    # Minified size indicator
+    frm_size = tk.Frame(frm_content)
+    frm_size.grid(row=2, column=1)
+
+    tk.Label(frm_size, text="Minified Size: ").grid(row=0, column=0)
+
+    var_size = tk.StringVar(value="0")
+    tk.Label(frm_size, textvariable=var_size).grid(row=0, column=1)
+
+    tk.Label(frm_size, text=" (max 2048)").grid(row=0, column=2)
+
+    handle_text()
+    window.mainloop()

--- a/src/tea-cli/tea_cli/main.py
+++ b/src/tea-cli/tea_cli/main.py
@@ -2,7 +2,7 @@ import argparse
 import logging
 import sys
 
-from tea_cli.commands import list_versions, quick_deploy
+from tea_cli.commands import list_versions, policy_sandbox, quick_deploy
 
 log = logging.getLogger(__name__)
 
@@ -21,7 +21,12 @@ def main(args=None):
 
 def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Thin Egress App Command Line Tool")
-    parser.add_argument("-v", help="enable verbose output", action="store_true", dest="verbose")
+    parser.add_argument(
+        "-v",
+        help="enable verbose output",
+        action="store_true",
+        dest="verbose",
+    )
     subparsers = parser.add_subparsers(
         required=True,
         dest="command",
@@ -42,6 +47,15 @@ def get_parser() -> argparse.ArgumentParser:
         ),
     )
     configure_subparser(parser_quickdeploy, quick_deploy)
+
+    parser_policy_sandbox = subparsers.add_parser(
+        "policy-sandbox",
+        help=(
+            "run a tkinter UI for exploring S3 session policies generated from "
+            "a bucket map"
+        ),
+    )
+    configure_subparser(parser_policy_sandbox, policy_sandbox)
 
     return parser
 


### PR DESCRIPTION
Moving the script here as part of the `tea-cli` tool so that its easier to install / run.

<img width="1385" height="752" alt="image" src="https://github.com/user-attachments/assets/ddb0b239-4543-4102-aa14-cc223050bc67" />


<details>
<summary>Pull Request Checklist</summary>

I have:
- [x] performed a self review of my code [I&A code style](https://github.com/asfadmin/ia-standards/blob/main/standards.md)
    - Resources and Data Structures are sorted by ABC or a defined sorting pattern
- [x] updated the documentation accordingly
- [x] verified required action checks are passing
- [x] deployed my code and all new and existing E2E/Integration tests passed
- [x] bumped the version number as appropriate
</details>